### PR TITLE
Arm64 support

### DIFF
--- a/docs/getting-started/kind.md
+++ b/docs/getting-started/kind.md
@@ -93,7 +93,7 @@ We use [Kustomize Components](https://github.com/kubernetes-sigs/kustomize/blob/
 2. Run the following to create the Tekton Pipeline, Task, etc. resources on your cluster:
 
     ```bash
-    $ kustomize build | kubectl apply -f -
+    $ plz run //third_party/binary/kubernetes-sigs/kustomize:kustomize -- build | kubectl apply -f -
     # Note: you can just run the below to see the generated Tekton Pipeline resources
     # $ kustomize build
     ```

--- a/pleasew
+++ b/pleasew
@@ -1,90 +1,145 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
+set -e
 set -u
 
-RED="\x1B[31m"
-GREEN="\x1B[32m"
-YELLOW="\x1B[33m"
-RESET="\x1B[0m"
+set -o errexit
 
-DEFAULT_URL_BASE="https://get.please.build"
+RED='\x1B[31m'
+GREEN='\x1B[32m'
+YELLOW='\x1B[33m'
+RESET='\x1B[0m'
+
+DEFAULT_URL_BASE='https://get.please.build'
 
 OS="$(uname)"
-# Don't have any builds other than amd64 at the moment.
-ARCH="amd64"
 
-# Check PLZ_CONFIG_PROFILE or fall back to arguments for a profile.
-PROFILE="${PLZ_CONFIG_PROFILE:-$(sed -E 's/.*--profile[= ]([^ ]+).*/\1/g' <<< "$*")}"
+if [ "${OS}" = 'Darwin' ]; then
+    # switch between mac amd64/arm64
+    ARCH="$(uname -m)"
+else
+    # default to amd64 on other operating systems
+    # because we only build intel binaries
+    ARCH='amd64'
+fi
+
+get_profile () {
+    while [ "${#}" -gt 0 ]
+    do
+        case "${1}" in
+            --profile=*) echo "${1#*=}"; return;;
+            --profile) echo "${2}"; return;;
+            *) shift;;
+        esac
+    done
+}
+
+# Check `PLZ_CONFIG_PROFILE` or fall back to arguments for a profile.
+PROFILE="${PLZ_CONFIG_PROFILE:-$(get_profile "${@}")}"
 
 # Config files on order of precedence high to low.
-CONFIGS=(
-  ".plzconfig.local"
-  ".plzconfig_${OS}_${ARCH}"
-  "${PROFILE:+.plzconfig.$PROFILE}"
-  ".plzconfig"
-  "$HOME/.config/please/plzconfig"
-  "/etc/please/plzconfig"
-)
+CONFIGS="$(cat <<- EOS
+	.plzconfig.local
+	${PROFILE:+.plzconfig.${PROFILE}}
+	.plzconfig_${OS}_${ARCH}
+	.plzconfig
+	${HOME}/.config/please/plzconfig
+	/etc/please/plzconfig
+EOS
+)"
 
-function read_config() {
-   grep -i "$1" "${CONFIGS[@]}" 2>/dev/null | head -n 1
+read_config() {
+    # Disable globbing to ensure word-splitting is safe.
+    set -f
+
+    old_ifs="${IFS}"
+    search_term="${1}"
+
+    IFS='
+'
+
+    # This is intended, we *do* want word-splitting here.
+    # shellcheck disable=2086
+    set -- ${CONFIGS}
+
+    grep -i "${search_term}" "${@}" 2> /dev/null | head -n 1
+
+    IFS="${old_ifs}"
+    set +f
 }
 
 # We might already have it downloaded...
-LOCATION="$(read_config "^location" | cut -d '=' -f 2 | tr -d ' ')"
-if [ -z "$LOCATION" ]; then
-    if [ -z "$HOME" ]; then
-        echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
+LOCATION="$(read_config '^location' | cut -d '=' -f 2 | tr -d ' ')"
+
+if [ "${LOCATION:+x}" != 'x' ]; then
+    if [ "${HOME:+x}" != 'x' ]; then
+        # shellcheck disable=2016
+        printf >&2 '%b$HOME not set, not sure where to look for Please.%b\n' "${RED}" "${RESET}"
         exit 1
     fi
+
     LOCATION="${HOME}/.please"
 else
     # It can contain a literal ~, need to explicitly handle that.
-    LOCATION="${LOCATION/\~/$HOME}"
+    LOCATION="$(echo "${LOCATION}" | sed "s|~|${HOME}|")"
 fi
+
 # If this exists at any version, let it handle any update.
 TARGET="${LOCATION}/please"
-if [ -f "$TARGET" ]; then
-    exec "$TARGET" ${PLZ_ARGS:-} "$@"
+
+if [ -f "${TARGET}" ]; then
+    # shellcheck disable=2086
+    exec "${TARGET}" ${PLZ_ARGS:-} "${@}"
 fi
 
-URL_BASE="$(read_config "^downloadlocation" | cut -d '=' -f 2 | tr -d ' ')"
-if [ -z "$URL_BASE" ]; then
-    URL_BASE=$DEFAULT_URL_BASE
+URL_BASE="$(read_config '^downloadlocation' | cut -d '=' -f 2 | tr -d ' ')"
+
+if [ "${URL_BASE:+x}" != 'x' ]; then
+    URL_BASE="${DEFAULT_URL_BASE}"
 fi
+
 URL_BASE="${URL_BASE%/}"
 
-VERSION="$(read_config "^version[^a-z]")"
-VERSION="${VERSION#*=}"    # Strip until after first =
-VERSION="${VERSION/ /}"    # Remove all spaces
-VERSION="${VERSION#>=}"    # Strip any initial >=
-if [ -z "$VERSION" ]; then
-    echo -e >&2 "${YELLOW}Can't determine version, will use latest.${RESET}"
-    VERSION=$(curl -fsSL ${URL_BASE}/latest_version)
+VERSION="$(read_config '^version[^a-z]')"
+VERSION="${VERSION#*=}"                    # Strip until after first =
+VERSION="$(echo "${VERSION}" | tr -d ' ')" # Remove all spaces
+VERSION="${VERSION#>=}"                    # Strip any initial >=
+
+if [ "${VERSION:+x}" != 'x' ]; then
+    printf >&2 "%bCan't determine version, will use latest.%b\n" "${YELLOW}" "${RESET}"
+    VERSION=$(curl -fsSL "${URL_BASE}"/latest_version)
 fi
 
 # Find the os / arch to download. You can do this quite nicely with go env
 # but we use this script on machines that don't necessarily have Go itself.
-if [ "$OS" = "Linux" ]; then
-    GOOS="linux"
-elif [ "$OS" = "Darwin" ]; then
-    GOOS="darwin"
+if [ "${OS}" = 'Linux' ]; then
+    GOOS='linux'
+elif [ "${OS}" = 'Darwin' ]; then
+    GOOS='darwin'
+elif [ "${OS}" = 'FreeBSD' ]; then
+    GOOS='freebsd'
 else
-    echo -e >&2 "${RED}Unknown operating system $OS${RESET}"
+    printf >&2 '%bUnknown operating system %s%b\n' "${RED}" "${OS}" "${RESET}"
     exit 1
 fi
 
 PLEASE_URL="${URL_BASE}/${GOOS}_${ARCH}/${VERSION}/please_${VERSION}.tar.xz"
 DIR="${LOCATION}/${VERSION}"
+
 # Potentially we could reuse this but it's easier not to really.
-if [ ! -d "$DIR" ]; then
-    rm -rf "$DIR"
+if [ ! -d "${DIR}" ]; then
+    rm -Rf "${DIR}"
 fi
-echo -e >&2 "${GREEN}Downloading Please ${VERSION} to ${DIR}...${RESET}"
-mkdir -p "$DIR"
-curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "$DIR"
+
+printf >&2 '%bDownloading Please %s to %s...%b\n' "${GREEN}" "${VERSION}" "${DIR}" "${RESET}"
+mkdir -p "${DIR}"
+curl -fsSL "${PLEASE_URL}" | tar -xJpf- --strip-components=1 -C "${DIR}"
+
 # Link it all back up a dir
-for x in $(ls "$DIR"); do
-    ln -sf "${DIR}/${x}" "$LOCATION"
+for x in "${DIR}"/*; do
+    ln -sf "${x}" "${LOCATION}"
 done
-echo -e >&2 "${GREEN}Should be good to go now, running plz...${RESET}"
-exec "$TARGET" ${PLZ_ARGS:-} "$@"
+
+printf >&2 '%bShould be good to go now, running plz...%b\n' "${GREEN}" "${RESET}"
+# shellcheck disable=2086
+exec "${TARGET}" ${PLZ_ARGS:-} "${@}"

--- a/third_party/binary/kubernetes-sigs/kustomize/BUILD
+++ b/third_party/binary/kubernetes-sigs/kustomize/BUILD
@@ -6,6 +6,7 @@ remote_file(
     extract = True,
     hashes = [
         "1159c5c17c964257123b10e7d8864e9fe7f9a580d4124a388e746e4003added3",  # linux-amd64
+        "11bfc053dc40c85aa2707f03778b9780011f9ec985251e713e33428f660c8ab4",  # linux_arm64
     ],
     url = f"https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F{VERSION}/kustomize_{VERSION}_{CONFIG.OS}_{CONFIG.ARCH}.tar.gz",
     visibility = ["PUBLIC"],

--- a/third_party/binary/mikefarah/yq/BUILD
+++ b/third_party/binary/mikefarah/yq/BUILD
@@ -6,6 +6,7 @@ remote_file(
     extract = True,
     hashes = [
         "0e105edbb0ebc7c4115c610168f1d6b0ff3ceb38043dac92e18fa0698130d69f",  # linux_amd64
+        "bd7f08ee1e9f77c14bdf4c20f88afd3e5573401b31d721d3d8b08f9e6164f322",  # linux_arm64
     ],
     url = f"https://github.com/mikefarah/yq/releases/download/{VERSION}/yq_{CONFIG.OS}_{CONFIG.ARCH}.tar.gz",
     visibility = [

--- a/third_party/binary/rancher/k3d/BUILD
+++ b/third_party/binary/rancher/k3d/BUILD
@@ -5,6 +5,7 @@ remote_file(
     binary = True,
     hashes = [
         "786151745379e511bd4dd95d1593241bb2b0a1d91e088573a1a1cb104732a3bd",  # linux-amd64
+        "cf12987491f3092884f71e263f58dbe818dadba40937ae99b1e71a1a83548ef0",  # linux_arm64
     ],
     url = f"https://github.com/rancher/k3d/releases/download/v{VERSION}/k3d-{CONFIG.OS}-{CONFIG.ARCH}",
     visibility = ["//build/k8s/k3d/..."],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -2,6 +2,7 @@ VERSION = "1.18"
 
 go_toolchain(
     name = "toolchain",
-    hashes = ["e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f"],
+    hashes = ["e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f",
+              "78a8e3754a9cf7518bb283fd7d4a6fff0979a41e559cc568f9186b20851a9995",],
     version = VERSION,
-)
+) 


### PR DESCRIPTION
Could you officially support ARM64 as well as AMD64?

This PR is currently working with the following exceptions

``` console

└─$ plz build //...                                                           
Build stopped after 1.49s. 2 targets failed:
    //examples/pipelines/scorecard-project/pipelinerun:pipelinerun
Error building target //examples/pipelines/scorecard-project/pipelinerun:pipelinerun: exit status 1
'GITHUB_TOKEN' is not set.

    //third_party/binary/tatskaari/go-deps:go-deps
1 error occurred:
        * Error retrieving https://github.com/Tatskaari/go-deps/releases/download/v1.4.2/go_deps_v1.4.2_linux_arm64: 404 Not Found

```
`scorecard` is because I don't have the required Github token and `go-deps` does not support ARM64 yet, though there is an [issue](https://github.com/Tatskaari/go-deps/issues/28) for it


I've not made the changes to enable ARM64 packages to be created, but think that would be the next step if you want to support this arch.

Thanks!