### PR TITLE
Use base pipeline name + suffix from kustomization for generated pipelines (Fixes #129)

### DIFF
--- a/cmd/draconctl/pipelines/build.go
+++ b/cmd/draconctl/pipelines/build.go
@@ -65,7 +65,7 @@ func buildPipeline(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s: could not resolve base pipeline and tasks: %w", kustomizationDir, err)
 	}
 
-	k8sBackend, err := pipelines.NewTektonV1Beta1Backend(basePipeline, taskList, kustomization.NamePrefix, kustomization.NameSuffix)
+	k8sBackend, err := pipelines.NewTektonV1Beta1Backend(basePipeline, taskList, kustomization.NameSuffix)
 	if err != nil {
 		return fmt.Errorf("could not initialise backend: %w", err)
 	}

--- a/pkg/pipelines/tektonV1Beta1.go
+++ b/pkg/pipelines/tektonV1Beta1.go
@@ -35,7 +35,6 @@ type Kustomization struct {
 type tektonV1Beta1Backend struct {
 	pipeline *tektonV1Beta1API.Pipeline
 	tasks    []*tektonV1Beta1API.Task
-	prefix   string
 	suffix   string
 }
 
@@ -167,12 +166,12 @@ func (pk *Kustomization) ResolveKustomizationResources(ctx context.Context) (*te
 
 // NewTektonBackend returns an implementation of the Backend interface that will produce a Tekton
 // Pipeline object with all the configured tasks.
-func NewTektonV1Beta1Backend(basePipeline *tektonV1Beta1API.Pipeline, tasks []*tektonV1Beta1API.Task, prefix, suffix string) (Backend[*tektonV1Beta1API.Pipeline], error) {
+func NewTektonV1Beta1Backend(basePipeline *tektonV1Beta1API.Pipeline, tasks []*tektonV1Beta1API.Task, suffix string) (Backend[*tektonV1Beta1API.Pipeline], error) {
 	if len(tasks) == 0 {
 		return nil, errors.Errorf("%w", ErrNoTasks)
 	}
 
-	tektonBackend := &tektonV1Beta1Backend{pipeline: basePipeline, tasks: tasks[:], prefix: prefix, suffix: suffix}
+	tektonBackend := &tektonV1Beta1Backend{pipeline: basePipeline, tasks: tasks[:], suffix: suffix}
 	for _, task := range tasks {
 		// TODO(?): revisit if we need this in the future
 		// fixTaskPrefixSuffix(task, prefix, suffix)
@@ -191,7 +190,7 @@ func NewTektonV1Beta1Backend(basePipeline *tektonV1Beta1API.Pipeline, tasks []*t
 }
 
 func (tb *tektonV1Beta1Backend) Generate() (*tektonV1Beta1API.Pipeline, error) {
-	tb.pipeline.Name = tb.prefix + tb.pipeline.Name + tb.suffix
+	tb.pipeline.Name = tb.pipeline.Name + tb.suffix
 	pipelineWorkspaces := map[string]struct{}{}
 	anchors := map[string][]string{}
 


### PR DESCRIPTION
Instead of using the kustomization prefix + the base pipeline name + the kustomization suffix, the Generate method of the `TektonV1Beta1` backend is modified to only use the base pipeline and the suffix to make things simpler and more straightforward.