### PR TITLE
Minor fix to prevent failures of database migrations tests

### DIFF
--- a/cmd/draconctl/migrations/inspect.go
+++ b/cmd/draconctl/migrations/inspect.go
@@ -56,18 +56,20 @@ func inspectMigrations(cmd *cobra.Command, args []string) error {
 			Dirty   bool
 		}{latestMigration, isDirty}
 
-		marshaledBytes, err := json.Marshal(jsonOutput)
+		var marshaledBytes []byte
+		marshaledBytes, err = json.Marshal(jsonOutput)
 		if err != nil {
 			return fmt.Errorf("could not marshal JSON output: %w", err)
 		}
-		fmt.Fprintln(cmd.OutOrStderr(), string(marshaledBytes))
+
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(marshaledBytes))
 	} else {
-		table := tablewriter.NewWriter(os.Stdout) //cmd.OutOrStdout())
+		table := tablewriter.NewWriter(cmd.OutOrStdout())
 		table.SetHeader([]string{"", ""})
 		table.Append([]string{"Latest Migration Version", fmt.Sprintf("%d", latestMigration)})
 		table.Append([]string{"Has Failed Migrations", fmt.Sprintf("%v", isDirty)})
 		table.Render()
 	}
 
-	return nil
+	return err
 }


### PR DESCRIPTION
Stacked on top of https://github.com/ocurity/dracon/pull/155

In the last couple of days the migrations test have failed locally for no apparent reason, since no code related to them has changed, the dependency versions have not changed and neither have the migrations themselves. After a little bit of digging it looks like something in the ubuntu container is causing the 'OutOrStderr' function call in the migrations inspect command to return the stderr instead of stdout which in turn causes the jq check in the migrations bash script to get an empty input instead of the JSON doc which in turn causes it to fail immediately. Changing the 'OutOrStderr' to 'OutOrStdout' ensures that the code will always output to stdout as expected or whatever is the out stream.