### PR TITLE
fix 170: add more checks for unresolved components

### DIFF
--- a/pkg/components/metadata.go
+++ b/pkg/components/metadata.go
@@ -2,20 +2,35 @@ package components
 
 import "fmt"
 
+// LabelKey is the key of the label where the value must be a string of the
+// ComponentType enum
 const LabelKey string = "v1.dracon.ocurity.com/component"
 
+// ComponentType represents all the types of components that Dracon supports
 type ComponentType int
 
 const (
-	Base ComponentType = iota
+	// Unknown is the default component type value
+	Unknown ComponentType = iota
+	// Base represents the base component of a pipeline
+	Base
+	// Source represents the source component of a pipeline
 	Source
+	// Producer represents the producer component of a pipeline
 	Producer
+	// ProducerAggregator represents the producer aggregator component of a
+	// pipeline
 	ProducerAggregator
+	// Enricher represents the enricher component of a pipeline
 	Enricher
+	// EnricherAggregator represents the enricher aggregator component of a
+	// pipeline
 	EnricherAggregator
+	// Consumer represents the consumer component of a pipeline
 	Consumer
 )
 
+// String converts the ComponentType enum value to a string
 func (ct ComponentType) String() string {
 	switch ct {
 	case Base:
@@ -37,6 +52,8 @@ func (ct ComponentType) String() string {
 	}
 }
 
+// ToComponentType converts a string into a ComponentType enum value or
+// returns an error
 func ToComponentType(cts string) (ComponentType, error) {
 	switch cts {
 	case "base":
@@ -58,6 +75,8 @@ func ToComponentType(cts string) (ComponentType, error) {
 	}
 }
 
+// MustGetComponentType converts a string into a ComponentType enum value or
+// panics
 func MustGetComponentType(cts string) ComponentType {
 	ct, err := ToComponentType(cts)
 	if err != nil {

--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -14,10 +14,12 @@ import (
 type OrchestrationType int
 
 const (
+	// UnknownOrchestration is the default value for the enum
+	UnknownOrchestration OrchestrationType = iota
 	// Naive means that a component is deployed on the cluster automatically
 	// before a Pipeline is deployed without checking if it's a newer or older
 	// version.
-	Naive OrchestrationType = iota
+	Naive
 	// ExternalHelm means that a component is deployed on the cluster using
 	// Helm but the orchestrator itself is not involved in this process.
 	ExternalHelm
@@ -78,6 +80,9 @@ func FromReference(ctx context.Context, ref string) (Component, error) {
 	if err != nil {
 		return zero, err
 	}
+
+	addAnchorParameter(task)
+	addAnchorResult(task)
 
 	return Component{
 		Name:              task.Name,

--- a/pkg/components/types_test.go
+++ b/pkg/components/types_test.go
@@ -1,0 +1,34 @@
+package components
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tektonv1beta1api "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func TestComponentResolutionFromReference(t *testing.T) {
+	dereferencedComponent, err := FromReference(context.Background(), "pkg:helm/dracon-oss-components/producer-aggregator")
+	require.NoError(t, err)
+	require.Equal(t, Component{
+		Name:              "producer-aggregator",
+		Reference:         "pkg:helm/dracon-oss-components/producer-aggregator",
+		Repository:        "dracon-oss-components",
+		OrchestrationType: ExternalHelm,
+	}, dereferencedComponent)
+
+	dereferencedComponent, err = FromReference(context.Background(), "../../components/producers/golang-gosec")
+	require.NoError(t, err)
+	require.Equal(t, "producer-golang-gosec", dereferencedComponent.Name)
+	require.Equal(t, "../../components/producers/golang-gosec", dereferencedComponent.Reference)
+	require.Equal(t, Naive, dereferencedComponent.OrchestrationType)
+	require.Equal(t, Producer, dereferencedComponent.Type)
+	require.Equal(t, true, dereferencedComponent.Resolved)
+	require.NotNil(t, dereferencedComponent.Manifest)
+	require.Equal(t, "anchors", dereferencedComponent.Manifest.(*tektonv1beta1api.Task).Spec.Params[1].Name)
+	require.Equal(t, "anchor", dereferencedComponent.Manifest.(*tektonv1beta1api.Task).Spec.Results[0].Name)
+
+	_, err = FromReference(context.Background(), "../../components")
+	require.Error(t, err)
+}

--- a/pkg/pipelines/tektonv1beta1.go
+++ b/pkg/pipelines/tektonv1beta1.go
@@ -15,10 +15,14 @@ import (
 )
 
 var (
-	// ErrNoComponentsInKustomization is returned when a kustomization has no components listed
+	// ErrNoComponentsInKustomization is returned when a kustomization has no
+	// components listed
 	ErrNoComponentsInKustomization = errors.New("no components listed in kustomization")
 	// ErrNoTasks is returned when no tasks are provided to the Tekton backend
 	ErrNoTasks = errors.New("no tasks provided")
+	// ErrNotResolved is returned when a component that has not been resolved
+	// is passed to the Orchestrator
+	ErrNotResolved = errors.New("component has not been resolved")
 )
 
 // addParamsAndEnvVars will add parameters and environment variables to the producer task that will
@@ -145,6 +149,9 @@ func (k k8sOrchestrator) Prepare(ctx context.Context, pipelineComponents []compo
 
 	for i, pipelineComponent := range pipelineComponents {
 		if pipelineComponent.OrchestrationType == components.Naive {
+			if !pipelineComponent.Resolved || pipelineComponent.Manifest == nil {
+				return ErrNotResolved
+			}
 			k.clientset.Apply(ctx, pipelineComponent.Manifest, k.namespace, false)
 		} else if pipelineComponent.OrchestrationType == components.ExternalHelm {
 			componentSet, exists := helmManagedComponents[pipelineComponent.Repository]

--- a/pkg/pipelines/tektonv1beta1_test.go
+++ b/pkg/pipelines/tektonv1beta1_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	tektonv1beta1api "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 
+	"github.com/ocurity/dracon/pkg/components"
+	"github.com/ocurity/dracon/pkg/k8s/fake"
 	"github.com/ocurity/dracon/pkg/manifests"
 )
 
@@ -61,4 +64,73 @@ func TestResolveKustomizationResourceBase(t *testing.T) {
 			require.Equal(t, testCase.expectedPipeline, basePipeline)
 		})
 	}
+}
+
+func TestComponentPrepareChecks(t *testing.T) {
+	fakeClient, err := fake.NewFakeTypedClient(&tektonv1beta1api.Task{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Task",
+			APIVersion: tektonv1beta1api.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "producer-aggregator",
+			Namespace: "dracon",
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name": "dracon-oss-components",
+			},
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":    "Helm",
+				"v1.dracon.ocurity.com/component": "producer-aggregator",
+			},
+		},
+		Spec: tektonv1beta1api.TaskSpec{
+			Params: tektonv1beta1api.ParamSpecs{
+				tektonv1beta1api.ParamSpec{
+					Name: "anchors",
+					Type: tektonv1beta1api.ParamTypeArray,
+				},
+			},
+			Workspaces: []tektonv1beta1api.WorkspaceDeclaration{
+				{
+					Name: "output",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	orchestrator := k8sOrchestrator{
+		clientset: fakeClient,
+		namespace: "dracon",
+	}
+
+	componentList := []components.Component{
+		{
+			Name:              "producer-aggregator",
+			Reference:         "pkg:helm/dracon-oss-components/producer-aggregator",
+			Repository:        "dracon-oss-components",
+			Type:              components.ProducerAggregator,
+			OrchestrationType: components.ExternalHelm,
+		},
+	}
+	require.NoError(t, orchestrator.Prepare(context.Background(), componentList))
+	require.True(t, componentList[0].Resolved)
+	require.NotNil(t, componentList[0].Manifest)
+
+	componentList = []components.Component{
+		{
+			Name:              "producer-golang-gosec",
+			Reference:         "../../components/producers/golang-gosec",
+			OrchestrationType: components.Naive,
+			Resolved:          true,
+			Manifest:          componentList[0].Manifest,
+		},
+	}
+	require.NoError(t, orchestrator.Prepare(context.Background(), componentList))
+
+	componentList[0].Resolved = false
+	require.ErrorIs(t, orchestrator.Prepare(context.Background(), componentList), ErrNotResolved)
+
+	componentList[0].Resolved = true
+	componentList[0].Manifest = nil
+	require.ErrorIs(t, orchestrator.Prepare(context.Background(), componentList), ErrNotResolved)
 }


### PR DESCRIPTION
before deploying a pipeline we resolve all the components in two stages. first we resolve components that are in the local filesystem or that will be downloaded. then, in the 'Deploy' method of the orchestrator implementations we deploy unmanaged Tasks and check that all the managed Tasks are present in the cluster. we should have more checks that the unmanaged Tasks have been resolved correctly before trying to do anything with them.

Fixes #170
