### PR TITLE
176: marshal ComponentType and OrchestrationType as string

### DIFF
--- a/pkg/components/metadata_test.go
+++ b/pkg/components/metadata_test.go
@@ -1,0 +1,26 @@
+package components
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentTypeMarshaling(t *testing.T) {
+	var testVal struct {
+		Type ComponentType
+	}
+
+	testVal.Type = Base
+	marshaled, err := json.Marshal(testVal)
+	require.NoError(t, err)
+	require.Equal(t, `{"Type":"base"}`, string(marshaled))
+
+	var unmarshaledTestVal struct {
+		Type ComponentType
+	}
+
+	require.NoError(t, json.Unmarshal(marshaled, &unmarshaledTestVal))
+	require.Equal(t, Base, unmarshaledTestVal.Type)
+}

--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -1,7 +1,9 @@
 package components
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -24,6 +26,65 @@ const (
 	// Helm but the orchestrator itself is not involved in this process.
 	ExternalHelm
 )
+
+// String converts the OrchestrationType to a string
+func (ot OrchestrationType) String() string {
+	switch ot {
+	case UnknownOrchestration:
+		return "unknown"
+	case Naive:
+		return "naive"
+	case ExternalHelm:
+		return "external-helm"
+	default:
+		panic(errors.Errorf("unknown orchestration type: %d", ot))
+	}
+}
+
+// MarshalJSON marshals an `OrchestrationType` into JSON bytes
+func (ot OrchestrationType) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + ot.String() + `"`), nil
+}
+
+// MarshalText marshals the `OrchestrationType` into text bytes
+func (ot OrchestrationType) MarshalText() ([]byte, error) {
+	return []byte(`"` + ot.String() + `"`), nil
+}
+
+// UnmarshalJSON unmarshalls bytes into an `OrchestrationType`
+func (ot *OrchestrationType) UnmarshalJSON(b []byte) error {
+	b = bytes.Trim(bytes.Trim(b, `"`), ` `)
+	parsedOrchestrationType, err := ToOrchestrationType(string(b))
+	if err == nil {
+		*ot = parsedOrchestrationType
+	}
+	return err
+}
+
+// UnmarshalText unmarshalls bytes into an `OrchestrationType`
+func (ot *OrchestrationType) UnmarshalText(text []byte) error {
+	text = bytes.Trim(bytes.Trim(text, `"`), ` `)
+	parsedOrchestrationType, err := ToOrchestrationType(string(text))
+	if err == nil {
+		*ot = parsedOrchestrationType
+	}
+	return err
+}
+
+// ToOrchestrationType converts a string into an OrchestrationType enum value
+// or returns an error
+func ToOrchestrationType(cts string) (OrchestrationType, error) {
+	switch cts {
+	case "unknown":
+		return UnknownOrchestration, nil
+	case "naive":
+		return Naive, nil
+	case "external-helm":
+		return ExternalHelm, nil
+	default:
+		return UnknownOrchestration, fmt.Errorf("%s: unknown orchestration type", cts)
+	}
+}
 
 // Component represents a Dracon component. At the moment it can only be a
 // Tekton Task, but in the future it might represent other things too.

--- a/pkg/pipelines/tektonv1beta1_utils.go
+++ b/pkg/pipelines/tektonv1beta1_utils.go
@@ -43,7 +43,10 @@ import (
 // addAnchorResult adds an `anchor` entry to the results section of a Task. This helps reduce the
 // amount of boilerplate needed to be written by a user to introduce a component.
 func addAnchorResult(task *tektonv1beta1api.Task) {
-	if task.Labels[components.LabelKey] == components.Consumer.String() || task.Labels[components.LabelKey] == components.Base.String() {
+	noResultAnchorNeeded, err := components.LabelValueOneOf(task.Labels, components.Consumer, components.Base)
+	if err != nil {
+		panic(err)
+	} else if noResultAnchorNeeded {
 		return
 	}
 


### PR DESCRIPTION
Data structures containing fields of ComponentType or Orchestration type get marshaled as integers, because these enums are integers themselves. The problem is that a human reading these YAML/JSONs will have trouble parsing the values, unless they are well acquainted with the values of the codebase. In order to make them more human-readable, this commit adds methods to both enums that allow them to be marshaled as string values. The enums remain as integer enums because this allows to use the enum also an implicit ordering of components in the case of the ComponentType.

fixes #176 