### PR TITLE
Ensure dracon_scan_* variables are set correctly

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,7 @@ Kibana and the bitnami charts to deploy instances of PostgreSQL and MongoDB.
 If you run the command:
 
 ```bash
-make dev-dracon DRACON_VERSION=v0.8.0
+make dev-dracon DRACON_VERSION=v0.13.0
 ```
 
 You will deploy the Elastic Operator on the cluster and the Dracon Helm

--- a/pkg/components/testdata/producers/cdxgen/task.yaml
+++ b/pkg/components/testdata/producers/cdxgen/task.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: producer-cdxgen
+  labels:
+    v1.dracon.ocurity.com/component: producer
+spec:
+  params:
+    - name: producer-cdxgen-flags
+      type: array
+      default: []
+    - name: producer-cdxgen-fetch-license
+      type: string
+      default: "false"
+    - name: producer-cdxgen-github-token
+      type: string
+      default: ""
+    - name: producer-cdxgen-astgen-ignore-file-pattern
+      type: string
+      default: ""
+    - name: producer-cdxgen-astgen-ignore-dirs
+      type: string
+      default: ""
+  volumes:
+    - name: scratch
+      emptyDir: {}
+  workspaces:
+    - name: output
+      description: The workspace containing the source-code to scan.
+  steps:
+    - name: run-cdxgen
+      image: ghcr.io/cyclonedx/cdxgen:v9.8.10
+      env:
+        - name: FETCH_LICENSE
+          value: $(params.producer-cdxgen-fetch-license)
+        - name: GITHUB_TOKEN
+          value: $(params.producer-cdxgen-github-token)
+        - name: ASTGEN_IGNORE_FILE_PATTERN
+          value: $(params.producer-cdxgen-astgen-ignore-file-pattern)
+        - name: ASTGEN_IGNORE_DIRS
+          value: $(params.producer-cdxgen-astgen-ignore-dirs)
+      script: node /opt/cdxgen/bin/cdxgen.js -r -p -o /scratch/out.json $(workspaces.output.path)/ --spec-version 1.4
+      volumeMounts:
+        - mountPath: /scratch
+          name: scratch
+
+    - name: produce-issues
+      imagePullPolicy: IfNotPresent
+      image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/cdxgen:latest'
+      command: ["/app/components/producers/cdxgen/cdxgen-parser"]
+      args:
+        - "-in=/scratch/out.json"
+        - "-out=$(workspaces.output.path)/.dracon/producers/cdxgen.pb"
+      volumeMounts:
+        - mountPath: /scratch
+          name: scratch

--- a/pkg/pipelines/tektonv1beta1_test.go
+++ b/pkg/pipelines/tektonv1beta1_test.go
@@ -80,7 +80,7 @@ func TestComponentPrepareChecks(t *testing.T) {
 			},
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by":    "Helm",
-				"v1.dracon.ocurity.com/component": "producer-aggregator",
+				"v1.dracon.ocurity.com/component": components.ProducerAggregator.String(),
 			},
 		},
 		Spec: tektonv1beta1api.TaskSpec{


### PR DESCRIPTION
Different versions of Tekton apply different validations to a Pipeline. If one uses more than version they will probably get a more complete list of errors for their pipelines. After using different versions of Tekton, I discovered that the `dracon_scan_*` parameters for the producer tasks are not set correctly.

This PR fixes two issues:
1. the `dracon_scan_*` parameters are set correctly
2. the code that adds anchors and the `dracon_scan_*` parameters is consolidated in one place and tests are added to make sure that the Tasks are processed before being packaged in a Helm package or before getting deployed on the fly by the orchestrator.

fixes #180 