### PR TITLE
188: fix typo in make variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ export
 ########################################
 .PHONY: components component-binaries cmd/draconctl/bin protos build publish-component-containers publish-containers draconctl-image draconctl-image-publish clean-protos clean
 
-$(component_binariess):
+$(component_binaries):
 	CGO_ENABLED=0 ./scripts/build_component_binary.sh $@
 
-component-binaries: $(component_binariess)
+component-binaries: $(component_binaries)
 
 $(component_containers): %/docker: %/bin
 	./scripts/build_component_container.sh $@


### PR DESCRIPTION
commit 1f104b0f fixes a typo in the component_binaries variable, however it didn't fix other instance of this variable used as dependencies, thus breaking the container publishing functionality. this commit fixes this.

Fixes #188 