### PR TITLE
Fix linter noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ clean: clean-protos clean-migrations-compose
 .PHONY: lint install-lint-tools tests go-tests fmt fmt-proto fmt-go install-go-fmt-tools migration-tests
 
 lint:
-	@reviewdog -fail-on-error $$([ "${CI}" = "true" ] && echo "-reporter=github-pr-review") -diff="git diff origin/main" -filter-mode=added -tee
+	@reviewdog -fail-on-error -diff="git diff origin/main" -filter-mode=added -tee
 
 install-lint-tools:
 	@go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
current linter setup is very noisy, also reviewdog's github integraton has a bug that double/tripple reports findings on removed code, however, when running locally, the linter works as expected, so we do the same for ci/cd

closes #198 