### PR TITLE
redirect reviewdog stderr to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ clean: clean-protos clean-migrations-compose
 .PHONY: lint install-lint-tools tests go-tests fmt fmt-proto fmt-go install-go-fmt-tools migration-tests
 
 lint:
-	@reviewdog -fail-on-error -diff="git diff origin/main" -filter-mode=added
+# we need to redirect stderr to stdout because Github actions don't capture the stderr lolz
+	@reviewdog -fail-on-error -diff="git diff origin/main" -filter-mode=added 2>&1
 
 install-lint-tools:
 	@go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
the lint Make target will output in stderr all the issues that reviewdog discovered for the diff under investigation, however that stderr is not captured by the Github action. we need to send the stderr to stdout so that we can see it in the Github action logs when the lint action fails.