### PR TITLE
🐛 Fix some producers failing if unable to extract code

### DIFF
--- a/components/producers/golang-gosec/main.go
+++ b/components/producers/golang-gosec/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/pkg/context"
@@ -50,11 +51,15 @@ func parseIssues(out *GoSecOut) ([]*v1.Issue, error) {
 			Confidence:  v1.Confidence(v1.Confidence_value[fmt.Sprintf("CONFIDENCE_%s", r.Confidence)]),
 			Description: r.Code,
 		}
+
+		// Extract the code snippet, if possible
 		code, err := context.ExtractCode(iss)
 		if err != nil {
-			return nil, err
+			slog.Warn("Failed to extract code snippet", "error", err)
+			code = ""
 		}
 		iss.ContextSegment = &code
+
 		issues = append(issues, iss)
 	}
 	return issues, nil

--- a/components/producers/kics/main.go
+++ b/components/producers/kics/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/producers"
@@ -80,13 +81,16 @@ func parseOut(results types.KICSOut) ([]*v1.Issue, error) {
 					file.ResourceName),
 				Description: string(description),
 			}
-			cs, err := context.ExtractCode(iss)
-			if err != nil {
-				return nil, err
-			}
-			iss.ContextSegment = &cs
-			issues = append(issues, iss)
 
+			// Extract the code snippet, if possible
+			code, err := context.ExtractCode(iss)
+			if err != nil {
+				slog.Warn("Failed to extract code snippet", "error", err)
+				code = ""
+			}
+			iss.ContextSegment = &code
+
+			issues = append(issues, iss)
 		}
 	}
 	return issues, nil

--- a/components/producers/semgrep/main.go
+++ b/components/producers/semgrep/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/producers/semgrep/types"
@@ -63,11 +64,15 @@ func parseIssues(out types.SemgrepResults) ([]*v1.Issue, error) {
 			Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
 			Description: fmt.Sprintf("%s\n extra lines: %s", r.Extra.Message, r.Extra.Lines),
 		}
-		cs, err := context.ExtractCode(iss)
+
+		// Extract the code snippet, if possible
+		code, err := context.ExtractCode(iss)
 		if err != nil {
-			return nil, err
+			slog.Warn("Failed to extract code snippet", "error", err)
+			code = ""
 		}
-		iss.ContextSegment = &cs
+		iss.ContextSegment = &code
+
 		issues = append(issues, iss)
 	}
 	return issues, nil

--- a/components/producers/terraform-tfsec/main.go
+++ b/components/producers/terraform-tfsec/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/producers"
@@ -75,11 +76,15 @@ func parseOut(results types.TfSecOut) ([]*v1.Issue, error) {
 			Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
 			Description: string(description),
 		}
-		cs, err := context.ExtractCode(iss)
+
+		// Extract the code snippet, if possible
+		code, err := context.ExtractCode(iss)
 		if err != nil {
-			return nil, err
+			slog.Warn("Failed to extract code snippet", "error", err)
+			code = ""
 		}
-		iss.ContextSegment = &cs
+		iss.ContextSegment = &code
+
 		issues = append(issues, iss)
 	}
 	return issues, nil

--- a/components/producers/typescript-eslint/main.go
+++ b/components/producers/typescript-eslint/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/producers/typescript-eslint/types"
@@ -61,11 +62,15 @@ func parseIssues(out []types.ESLintIssue) ([]*v1.Issue, error) {
 				Confidence:  v1.Confidence_CONFIDENCE_MEDIUM,
 				Description: msg.Message,
 			}
-			cs, err := context.ExtractCode(iss)
+
+			// Extract the code snippet, if possible
+			code, err := context.ExtractCode(iss)
 			if err != nil {
-				return nil, err
+				slog.Warn("Failed to extract code snippet", "error", err)
+				code = ""
 			}
-			iss.ContextSegment = &cs
+			iss.ContextSegment = &code
+
 			issues = append(issues, iss)
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue where some producers failed if they were unable to extract the code for an `Issue`.

Instead, we now keep that field empty, and log a warning instead.