### PR TITLE
[OCU-113] 🐛 Fix `producer/semgrep` not supporting registry

### DIFF
--- a/components/producers/semgrep/README.md
+++ b/components/producers/semgrep/README.md
@@ -1,0 +1,12 @@
+# Producer: Semgrep
+
+This producer runs [the Semgrep CLI](https://semgrep.dev/docs/cli-reference) to produce SAST findings.
+
+## Parameters
+
+All parameters are optional. The producer works with the default configuration and uses the `"auto"` ruleset.
+
+| Name                            | Type     | Default       | Description                                                                            |
+| ------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------- |
+| `producer-semgrep-config-value` | `string` | `"auto"`      | The config for the Semgrep producer. Passed directly to the CLI via `--config`         |
+| `producer-semgrep-rules-yaml`   | `string` | `"rules: []"` | Additional rules passed to Semgrep https://semgrep.dev/docs/writing-rules/rule-syntax. |

--- a/components/producers/semgrep/task.yaml
+++ b/components/producers/semgrep/task.yaml
@@ -11,6 +11,9 @@ spec:
     type: string
     default: |
       rules: []
+  - name: producer-semgrep-config-value
+    type: string
+    default: auto
   volumes:
     - name: scratch
       emptyDir: {}
@@ -38,6 +41,7 @@ spec:
     - "scan"
     - "--config"
     - "/scratch/semgrep-rules.yaml"
+    - "--config=$(params.producer-semgrep-config-value)"
     - "--json"
     - "--output"
     - "/scratch/out.json"


### PR DESCRIPTION
This PR adds a new parameter `producer-semgrep-config-value` to the `producer/semgrep`. By default, it's set to `auto`.

Adding this new parameter makes the SemGrep producer immediately useful, without needing to define custom rules in YAML.

The binary also supports multiple `--config` parameters, so the two parameters don't interfere with each other.