### PR TITLE
Remove policy enricher from example pipelines

### DIFF
--- a/components/enrichers/policy/README.md
+++ b/components/enrichers/policy/README.md
@@ -1,5 +1,12 @@
 # Policy Enricher
 
+> **Warning:** This component has a memory limit of 5GB assigned to one of
+> it's dependencies. Make sure you provide sufficient resources when running it.
+>
+> For example, Docker Desktop by default only allocates 2GB to itself. You
+> MUST increase that limit manually in `Docker Desktop > Settings > Resources`
+> if you want to run this component locally.
+
 This enricher implements an MVP of the design outlined in
 [the enricher design document](/docs/designs/policy-enricher.md).
 In its current state it evaluates the `allow` rule of a single policy found

--- a/examples/pipelines/cdxgen-project/kustomization.yaml
+++ b/examples/pipelines/cdxgen-project/kustomization.yaml
@@ -7,7 +7,6 @@ components:
   - pkg:helm/dracon-oss-components/git-clone
   - pkg:helm/dracon-oss-components/producer-cdxgen
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-stdout-json

--- a/examples/pipelines/dast-project/kustomization.yaml
+++ b/examples/pipelines/dast-project/kustomization.yaml
@@ -7,7 +7,6 @@ components:
   - pkg:helm/dracon-oss-components/git-clone
   - pkg:helm/dracon-oss-components/producers/zaproxy
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/golang-project/kustomization.yaml
+++ b/examples/pipelines/golang-project/kustomization.yaml
@@ -8,7 +8,6 @@ components:
   - pkg:helm/dracon-oss-components/producer-golang-gosec
   - pkg:helm/dracon-oss-components/producer-golang-nancy
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/iac-project/kustomization.yaml
+++ b/examples/pipelines/iac-project/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - pkg:helm/dracon-oss-components/producer-kics
   - pkg:helm/dracon-oss-components/producer-terraform-tfsec
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/java-project/kustomization.yaml
+++ b/examples/pipelines/java-project/kustomization.yaml
@@ -8,7 +8,6 @@ components:
   - pkg:helm/dracon-oss-components/producer-dependency-check
   - pkg:helm/dracon-oss-components/producer-java-findsecbugs
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/misc-project/kustomization.yaml
+++ b/examples/pipelines/misc-project/kustomization.yaml
@@ -7,7 +7,6 @@ components:
   - pkg:helm/dracon-oss-components/git-clone
   - pkg:helm/dracon-oss-components/producer-ossf-scorecard
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/nancy-purl-project/kustomization.yaml
+++ b/examples/pipelines/nancy-purl-project/kustomization.yaml
@@ -7,7 +7,6 @@ components:
   - pkg:helm/dracon-oss-components/git-clone
   - pkg:helm/dracon-oss-components/producer-golang-nancy
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/python-project/kustomization.yaml
+++ b/examples/pipelines/python-project/kustomization.yaml
@@ -8,7 +8,6 @@ components:
   - pkg:helm/dracon-oss-components/producer-python-bandit
   - pkg:helm/dracon-oss-components/producer-python-pip-safety
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb

--- a/examples/pipelines/typescript-project/kustomization.yaml
+++ b/examples/pipelines/typescript-project/kustomization.yaml
@@ -8,7 +8,6 @@ components:
   - pkg:helm/dracon-oss-components/producer-typescript-npm-audit
   - pkg:helm/dracon-oss-components/producer-typescript-eslint
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-policy
   - pkg:helm/dracon-oss-components/enricher-deduplication
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb


### PR DESCRIPTION
This PR removes the `enrichers/policy` from the example pipelines.

Removing this because it requires 5GB of memory to run, but
Docker Desktop by default only assigns 2GB to itself. The
component can still be run, but requires users to manually
tweak their memory limit. We decided this is too complex for
an example pipeline and would cause more harm than good.

Also [added a warning to enrichers/policy:README about these memory requirements](https://github.com/ocurity/dracon/commit/ca533cd86b19648d372a727c7261e699c4e23dd6).