### PR TITLE
[OCU-104] Ensure Enrichers Always Produce an Output

### DIFF
--- a/components/enrichers/codeowners/main.go
+++ b/components/enrichers/codeowners/main.go
@@ -16,7 +16,6 @@ import (
 	owners "github.com/hairyhenderson/go-codeowners"
 
 	apiv1 "github.com/ocurity/dracon/api/proto/v1"
-	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/enrichers"
 )
 
@@ -81,7 +80,8 @@ func run() error {
 			}
 			enrichedIssues = append(enrichedIssues, eI)
 		}
-		return enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
+
+		return enrichers.WriteData(&apiv1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,
 		}, "codeowners")

--- a/components/enrichers/codeowners/main_test.go
+++ b/components/enrichers/codeowners/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	draconv1 "github.com/ocurity/dracon/api/proto/v1"
+	"github.com/ocurity/dracon/components/enrichers"
+)
+
+func TestHandlesZeroFindings(t *testing.T) {
+	indir, outdir := enrichers.SetupIODirs(t)
+
+	mockLaunchToolResponses := enrichers.GetEmptyLaunchToolResponse(t)
+	for i, r := range mockLaunchToolResponses {
+		// Write sample enriched responses to indir
+		encodedProto, err := proto.Marshal(r)
+		require.NoError(t, err)
+		rwPermission600 := os.FileMode(0o600)
+
+		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/input_%d_%s.tagged.pb", indir, i, r.ToolName), encodedProto, rwPermission600))
+	}
+
+	// Run the enricher
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
+	require.NoError(t, run())
+
+	// Check there is something in our output directory
+	files, err := os.ReadDir(outdir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, files)
+	assert.Len(t, files, 2)
+
+	// Check that both of them are EnrichedLaunchToolResponse
+	// and their Issue property is an empty list
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".raw.pb") {
+			continue
+		}
+
+		encodedProto, err := os.ReadFile(fmt.Sprintf("%s/%s", outdir, f.Name()))
+		require.NoError(t, err)
+
+		output := &draconv1.EnrichedLaunchToolResponse{}
+		require.NoError(t, proto.Unmarshal(encodedProto, output))
+
+		assert.Empty(t, output.Issues)
+	}
+}

--- a/components/enrichers/deduplication/main_test.go
+++ b/components/enrichers/deduplication/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	draconv1 "github.com/ocurity/dracon/api/proto/v1"
+	"github.com/ocurity/dracon/components/enrichers"
+)
+
+func TestRunsWithoutCrashing(t *testing.T) {
+	indir, outdir := enrichers.SetupIODirs(t)
+
+	connStr = "postgres://user:password@localhost:5432/dbname"
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
+
+	require.NoError(t, run())
+}
+
+func TestHandlesZeroFindings(t *testing.T) {
+	indir, outdir := enrichers.SetupIODirs(t)
+
+	// Create mock input data
+	mockLaunchToolResponses := enrichers.GetEmptyLaunchToolResponse(t)
+
+	for i, r := range mockLaunchToolResponses {
+		// Write sample enriched responses to indir
+		encodedProto, err := proto.Marshal(r)
+		require.NoError(t, err)
+		rwPermission600 := os.FileMode(0o600)
+
+		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/input_%d_%s.tagged.pb", indir, i, r.ToolName), encodedProto, rwPermission600))
+	}
+
+	// Launch the command
+	connStr = "postgres://user:password@localhost:5432/dbname"
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
+	require.NoError(t, run())
+
+	// Check there is something in our output directory
+	files, err := os.ReadDir(outdir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, files)
+	assert.Len(t, files, 2)
+
+	// Check that both of them are EnrichedLaunchToolResponse
+	// and their Issue property is an empty list
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".raw.pb") {
+			continue
+		}
+
+		encodedProto, err := os.ReadFile(fmt.Sprintf("%s/%s", outdir, f.Name()))
+		require.NoError(t, err)
+
+		output := &draconv1.EnrichedLaunchToolResponse{}
+		require.NoError(t, proto.Unmarshal(encodedProto, output))
+
+		assert.Empty(t, output.Issues)
+	}
+}
+
+func TestHandlesEnrichmentOfAllIssuesFailing(t *testing.T) {
+	indir, outdir := enrichers.SetupIODirs(t)
+
+	// Create mock input data
+	mockLaunchToolResponses := []*draconv1.LaunchToolResponse{
+		{
+			ToolName: "tool1",
+			Issues: []*draconv1.Issue{
+				{
+					Title: "issue1",
+					Uuid:  "uuid1",
+				},
+			},
+		},
+		{
+			ToolName: "tool2",
+			Issues: []*draconv1.Issue{
+				{
+					Title: "issue2",
+					Uuid:  "uuid2",
+				},
+			},
+		},
+	}
+
+	for i, r := range mockLaunchToolResponses {
+		// Write sample enriched responses to indir
+		encodedProto, err := proto.Marshal(r)
+		require.NoError(t, err)
+		rwPermission600 := os.FileMode(0o600)
+
+		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/input_%d_%s.tagged.pb", indir, i, r.ToolName), encodedProto, rwPermission600))
+	}
+
+	// Launch the command
+	connStr = "postgres://user:password@localhost:5432/dbname"
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
+
+	require.Error(t, run())
+}

--- a/components/enrichers/depsdev/main.go
+++ b/components/enrichers/depsdev/main.go
@@ -9,16 +9,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	packageurl "github.com/package-url/packageurl-go"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/enrichers"
-	"github.com/ocurity/dracon/pkg/cyclonedx"
-
 	"github.com/ocurity/dracon/components/enrichers/depsdev/types"
+	"github.com/ocurity/dracon/pkg/cyclonedx"
 )
 
 const defaultAnnotation = "Enriched Licenses"
@@ -29,13 +27,6 @@ var (
 	scoreCardInfo      string
 	annotation         string
 )
-
-func lookupEnvOrString(key string, defaultVal string) string {
-	if val, ok := os.LookupEnv(key); ok {
-		return val
-	}
-	return defaultVal
-}
 
 func makeURL(component cdx.Component, api bool) (string, error) {
 	instance, err := packageurl.FromString(component.PackageURL)
@@ -223,6 +214,7 @@ func run() error {
 			}
 			enrichedIssues = append(enrichedIssues, eI)
 		}
+
 		return enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,

--- a/components/enrichers/depsdev/main.go
+++ b/components/enrichers/depsdev/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	packageurl "github.com/package-url/packageurl-go"
@@ -16,6 +17,8 @@ import (
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/enrichers"
 	"github.com/ocurity/dracon/pkg/cyclonedx"
+
+	"github.com/ocurity/dracon/components/enrichers/depsdev/types"
 )
 
 const defaultAnnotation = "Enriched Licenses"
@@ -27,74 +30,11 @@ var (
 	annotation         string
 )
 
-// Check is a deps.dev ScoreCardV2 check
-type Check struct {
-	Name          string `json:"name,omitempty"`
-	Documentation struct {
-		Short string `json:"short,omitempty"`
-		URL   string `json:"url,omitempty"`
-	} `json:"documentation,omitempty"`
-	Score   int           `json:"score,omitempty"`
-	Reason  string        `json:"reason,omitempty"`
-	Details []interface{} `json:"details,omitempty"`
-}
-
-// ScorecardV2 is a deps.dev ScoreCardV2 result
-type ScorecardV2 struct {
-	Date string `json:"date,omitempty"`
-	Repo struct {
-		Name   string `json:"name,omitempty"`
-		Commit string `json:"commit,omitempty"`
-	} `json:"repo,omitempty"`
-	Scorecard struct {
-		Version string `json:"version,omitempty"`
-		Commit  string `json:"commit,omitempty"`
-	} `json:"scorecard,omitempty"`
-	Check    []Check       `json:"check,omitempty"`
-	Metadata []interface{} `json:"metadata,omitempty"`
-	Score    float64       `json:"score,omitempty"`
-}
-
-// Project is a deps.dev project
-type Project struct {
-	Type        string      `json:"type,omitempty"`
-	Name        string      `json:"name,omitempty"`
-	ObservedAt  int         `json:"observedAt,omitempty"`
-	Issues      int         `json:"issues,omitempty"`
-	Forks       int         `json:"forks,omitempty"`
-	Stars       int         `json:"stars,omitempty"`
-	Description string      `json:"description,omitempty"`
-	License     string      `json:"license,omitempty"`
-	DisplayName string      `json:"displayName,omitempty"`
-	Link        string      `json:"link,omitempty"`
-	ScorecardV2 ScorecardV2 `json:"scorecardV2,omitempty"`
-}
-
-// Version is a deps.dev version, main object in the response
-type Version struct {
-	Version                string        `json:"version,omitempty"`
-	SymbolicVersions       []interface{} `json:"symbolicVersions,omitempty"`
-	RefreshedAt            int           `json:"refreshedAt,omitempty"`
-	IsDefault              bool          `json:"isDefault,omitempty"`
-	Licenses               []string      `json:"licenses,omitempty"`
-	DependentCount         int           `json:"dependentCount,omitempty"`
-	DependentCountDirect   int           `json:"dependentCountDirect,omitempty"`
-	DependentCountIndirect int           `json:"dependentCountIndirect,omitempty"`
-	Links                  struct {
-		Origins []string `json:"origins,omitempty"`
-	} `json:"links,omitempty"`
-	Projects        []Project     `json:"projects,omitempty"`
-	Advisories      []interface{} `json:"advisories,omitempty"`
-	RelatedPackages struct{}      `json:"relatedPackages,omitempty"`
-}
-type Response struct {
-	Package struct {
-		System string `json:"system,omitempty"`
-		Name   string `json:"name,omitempty"`
-	} `json:"package,omitempty"`
-	Owners         []interface{} `json:"owners,omitempty"`
-	Version        Version       `json:"version,omitempty"`
-	DefaultVersion string        `json:"defaultVersion,omitempty"`
+func lookupEnvOrString(key string, defaultVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultVal
 }
 
 func makeURL(component cdx.Component, api bool) (string, error) {
@@ -152,7 +92,7 @@ func addDepsDevLink(component cdx.Component) (cdx.Component, error) {
 }
 
 func addDepsDevInfo(component cdx.Component, annotations map[string]string) (cdx.Component, map[string]string, error) {
-	var depsResp Response
+	var depsResp types.Response
 	licenses := cdx.Licenses{}
 	url, err := makeURL(component, true)
 	if err != nil {

--- a/components/enrichers/depsdev/main_test.go
+++ b/components/enrichers/depsdev/main_test.go
@@ -19,6 +19,8 @@ import (
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/ocurity/dracon/components/enrichers"
 	"github.com/ocurity/dracon/pkg/cyclonedx"
+
+	"github.com/ocurity/dracon/components/enrichers/depsdev/types"
 )
 
 const (
@@ -78,15 +80,15 @@ func setup(t *testing.T) (string, *httptest.Server) {
 	dir := prepareIssue(t)
 
 	// setup server
-	response := Response{
-		Version: Version{
+	response := types.Response{
+		Version: types.Version{
 			Licenses: []string{license},
-			Projects: []Project{
+			Projects: []types.Project{
 				{
-					ScorecardV2: ScorecardV2{
+					ScorecardV2: types.ScorecardV2{
 						Date:  "irrelevant",
 						Score: 5.5,
-						Check: []Check{
+						Check: []types.Check{
 							{
 								Name:   "foo",
 								Score:  2,

--- a/components/enrichers/depsdev/types/types.go
+++ b/components/enrichers/depsdev/types/types.go
@@ -2,30 +2,16 @@ package types
 
 // Check is a deps.dev ScoreCardV2 check
 type Check struct {
-	Name          string `json:"name,omitempty"`
-	Documentation struct {
-		Short string `json:"short,omitempty"`
-		URL   string `json:"url,omitempty"`
-	} `json:"documentation,omitempty"`
-	Score   int           `json:"score,omitempty"`
-	Reason  string        `json:"reason,omitempty"`
-	Details []interface{} `json:"details,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Score  int    `json:"score,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // ScorecardV2 is a deps.dev ScoreCardV2 result
 type ScorecardV2 struct {
-	Date string `json:"date,omitempty"`
-	Repo struct {
-		Name   string `json:"name,omitempty"`
-		Commit string `json:"commit,omitempty"`
-	} `json:"repo,omitempty"`
-	Scorecard struct {
-		Version string `json:"version,omitempty"`
-		Commit  string `json:"commit,omitempty"`
-	} `json:"scorecard,omitempty"`
-	Check    []Check       `json:"check,omitempty"`
-	Metadata []interface{} `json:"metadata,omitempty"`
-	Score    float64       `json:"score,omitempty"`
+	Date  string  `json:"date,omitempty"`
+	Check []Check `json:"check,omitempty"`
+	Score float64 `json:"score,omitempty"`
 }
 
 // Project is a deps.dev project
@@ -45,27 +31,18 @@ type Project struct {
 
 // Version is a deps.dev version, main object in the response
 type Version struct {
-	Version                string        `json:"version,omitempty"`
-	SymbolicVersions       []interface{} `json:"symbolicVersions,omitempty"`
-	RefreshedAt            int           `json:"refreshedAt,omitempty"`
-	IsDefault              bool          `json:"isDefault,omitempty"`
-	Licenses               []string      `json:"licenses,omitempty"`
-	DependentCount         int           `json:"dependentCount,omitempty"`
-	DependentCountDirect   int           `json:"dependentCountDirect,omitempty"`
-	DependentCountIndirect int           `json:"dependentCountIndirect,omitempty"`
-	Links                  struct {
-		Origins []string `json:"origins,omitempty"`
-	} `json:"links,omitempty"`
-	Projects        []Project     `json:"projects,omitempty"`
-	Advisories      []interface{} `json:"advisories,omitempty"`
-	RelatedPackages struct{}      `json:"relatedPackages,omitempty"`
+	Version                string    `json:"version,omitempty"`
+	RefreshedAt            int       `json:"refreshedAt,omitempty"`
+	IsDefault              bool      `json:"isDefault,omitempty"`
+	Licenses               []string  `json:"licenses,omitempty"`
+	DependentCount         int       `json:"dependentCount,omitempty"`
+	DependentCountDirect   int       `json:"dependentCountDirect,omitempty"`
+	DependentCountIndirect int       `json:"dependentCountIndirect,omitempty"`
+	Projects               []Project `json:"projects,omitempty"`
 }
+
+// Response is a deps.dev response
 type Response struct {
-	Package struct {
-		System string `json:"system,omitempty"`
-		Name   string `json:"name,omitempty"`
-	} `json:"package,omitempty"`
-	Owners         []interface{} `json:"owners,omitempty"`
-	Version        Version       `json:"version,omitempty"`
-	DefaultVersion string        `json:"defaultVersion,omitempty"`
+	Version        Version `json:"version,omitempty"`
+	DefaultVersion string  `json:"defaultVersion,omitempty"`
 }

--- a/components/enrichers/depsdev/types/types.go
+++ b/components/enrichers/depsdev/types/types.go
@@ -1,0 +1,71 @@
+package types
+
+// Check is a deps.dev ScoreCardV2 check
+type Check struct {
+	Name          string `json:"name,omitempty"`
+	Documentation struct {
+		Short string `json:"short,omitempty"`
+		URL   string `json:"url,omitempty"`
+	} `json:"documentation,omitempty"`
+	Score   int           `json:"score,omitempty"`
+	Reason  string        `json:"reason,omitempty"`
+	Details []interface{} `json:"details,omitempty"`
+}
+
+// ScorecardV2 is a deps.dev ScoreCardV2 result
+type ScorecardV2 struct {
+	Date string `json:"date,omitempty"`
+	Repo struct {
+		Name   string `json:"name,omitempty"`
+		Commit string `json:"commit,omitempty"`
+	} `json:"repo,omitempty"`
+	Scorecard struct {
+		Version string `json:"version,omitempty"`
+		Commit  string `json:"commit,omitempty"`
+	} `json:"scorecard,omitempty"`
+	Check    []Check       `json:"check,omitempty"`
+	Metadata []interface{} `json:"metadata,omitempty"`
+	Score    float64       `json:"score,omitempty"`
+}
+
+// Project is a deps.dev project
+type Project struct {
+	Type        string      `json:"type,omitempty"`
+	Name        string      `json:"name,omitempty"`
+	ObservedAt  int         `json:"observedAt,omitempty"`
+	Issues      int         `json:"issues,omitempty"`
+	Forks       int         `json:"forks,omitempty"`
+	Stars       int         `json:"stars,omitempty"`
+	Description string      `json:"description,omitempty"`
+	License     string      `json:"license,omitempty"`
+	DisplayName string      `json:"displayName,omitempty"`
+	Link        string      `json:"link,omitempty"`
+	ScorecardV2 ScorecardV2 `json:"scorecardV2,omitempty"`
+}
+
+// Version is a deps.dev version, main object in the response
+type Version struct {
+	Version                string        `json:"version,omitempty"`
+	SymbolicVersions       []interface{} `json:"symbolicVersions,omitempty"`
+	RefreshedAt            int           `json:"refreshedAt,omitempty"`
+	IsDefault              bool          `json:"isDefault,omitempty"`
+	Licenses               []string      `json:"licenses,omitempty"`
+	DependentCount         int           `json:"dependentCount,omitempty"`
+	DependentCountDirect   int           `json:"dependentCountDirect,omitempty"`
+	DependentCountIndirect int           `json:"dependentCountIndirect,omitempty"`
+	Links                  struct {
+		Origins []string `json:"origins,omitempty"`
+	} `json:"links,omitempty"`
+	Projects        []Project     `json:"projects,omitempty"`
+	Advisories      []interface{} `json:"advisories,omitempty"`
+	RelatedPackages struct{}      `json:"relatedPackages,omitempty"`
+}
+type Response struct {
+	Package struct {
+		System string `json:"system,omitempty"`
+		Name   string `json:"name,omitempty"`
+	} `json:"package,omitempty"`
+	Owners         []interface{} `json:"owners,omitempty"`
+	Version        Version       `json:"version,omitempty"`
+	DefaultVersion string        `json:"defaultVersion,omitempty"`
+}

--- a/components/enrichers/policy/main_test.go
+++ b/components/enrichers/policy/main_test.go
@@ -23,7 +23,37 @@ import (
 const (
 	// numFindings         = 20.
 	expectedNumFindings = 5 // we have 5 distinct uuids
+	defaultPolicy       = "cGFja2FnZSBleGFtcGxlLnBvbGljeVNhdAoKZGVmYXVsdCBhbGxvdyA6PSBmYWxzZQoKYWxsb3cgPXRydWUgewogICAgcHJpbnQoaW5wdXQpCiAgICBjaGVja19zZXZlcml0eQp9CgpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfTE9XIgp9CgpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfSElHSCIKfQpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfTUVESVVNIgp9Cg=="
 )
+
+func setupRegoServer(t *testing.T) *httptest.Server {
+	// setup server
+	expected := "{}"
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type bod map[string]interface{}
+		var body bod
+
+		if strings.Contains(r.URL.String(), "/v1/policies") {
+			_, err := fmt.Fprintf(w, "{}")
+			require.NoError(t, err)
+		}
+
+		if strings.Contains(r.URL.String(), "/v1/data") {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			if strings.Contains(fmt.Sprintf("%#v\n ", body), "SEVERITY_CRITICAL") {
+				_, err := fmt.Fprintf(w, "{\"result\":{\"allow\":false}}")
+				require.NoError(t, err)
+			} else {
+				_, err := fmt.Fprintf(w, "{\"result\":{\"allow\":true}}")
+				require.NoError(t, err)
+			}
+		}
+
+		_, err := fmt.Fprint(w, expected)
+		require.NoError(t, err)
+	}))
+	return svr
+}
 
 func genSampleIssues() []*v1.Issue {
 	sev := []v1.Severity{
@@ -51,9 +81,7 @@ func genSampleIssues() []*v1.Issue {
 }
 
 func TestParseIssues(t *testing.T) {
-	// prepare
-	dir, err := os.MkdirTemp("/tmp", "")
-	require.NoError(t, err)
+	indir, outdir := enrichers.SetupIODirs(t)
 
 	rawIssues := genSampleIssues()
 
@@ -71,41 +99,22 @@ func TestParseIssues(t *testing.T) {
 	// write sample raw issues in mktemp
 	out, err := proto.Marshal(&orig)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(dir+"/policySat.tagged.pb", out, 0o600))
-	enrichers.SetReadPathForTests(dir)
-	enrichers.SetWritePathForTests(dir)
+	require.NoError(t, os.WriteFile(indir+"/policySat.tagged.pb", out, 0o600))
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
 	policy = "cGFja2FnZSBleGFtcGxlLnBvbGljeVNhdAoKZGVmYXVsdCBhbGxvdyA6PSBmYWxzZQoKYWxsb3cgPXRydWUgewogICAgcHJpbnQoaW5wdXQpCiAgICBjaGVja19zZXZlcml0eQp9CgpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfTE9XIgp9CgpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfSElHSCIKfQpjaGVja19zZXZlcml0eSB7CiAgICBpbnB1dC5zZXZlcml0eSA9PSAiU0VWRVJJVFlfTUVESVVNIgp9Cg=="
 
-	// setup server
-	expected := "{}"
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		type bod map[string]interface{}
-		var body bod
-
-		if strings.Contains(r.URL.String(), "/v1/policies") {
-			fmt.Fprintf(w, "{}")
-		}
-
-		if strings.Contains(r.URL.String(), "/v1/data") {
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-			if strings.Contains(fmt.Sprintf("%#v\n ", body), "SEVERITY_CRITICAL") {
-				fmt.Fprintf(w, "{\"result\":{\"allow\":false}}")
-			} else {
-				fmt.Fprintf(w, "{\"result\":{\"allow\":true}}")
-			}
-		}
-
-		fmt.Fprint(w, expected)
-	}))
+	svr := setupRegoServer(t)
 	defer svr.Close()
+
 	regoServer = svr.URL
+	policy = defaultPolicy
+	require.NoError(t, run())
 
-	run()
-
-	assert.FileExists(t, dir+"/policySat.policy.enriched.pb", "file was not created")
+	assert.FileExists(t, outdir+"/policySat.policy.enriched.pb", "file was not created")
 
 	// load *enriched.pb
-	pbBytes, err := os.ReadFile(dir + "/policySat.policy.enriched.pb")
+	pbBytes, err := os.ReadFile(outdir + "/policySat.policy.enriched.pb")
 	require.NoError(t, err)
 
 	res := v1.EnrichedLaunchToolResponse{}
@@ -116,5 +125,53 @@ func TestParseIssues(t *testing.T) {
 		if finding.RawIssue.Severity != v1.Severity_SEVERITY_CRITICAL {
 			assert.Contains(t, fmt.Sprintf("%#v\n", finding.Annotations), "\"Policy Pass: example/policySat\":\"true\"")
 		}
+	}
+}
+
+func TestHandlesZeroFindings(t *testing.T) {
+	indir, outdir := enrichers.SetupIODirs(t)
+
+	mockLaunchToolResponses := enrichers.GetEmptyLaunchToolResponse(t)
+
+	for i, r := range mockLaunchToolResponses {
+		// Write sample enriched responses to indir
+		encodedProto, err := proto.Marshal(r)
+		require.NoError(t, err)
+		rwPermission600 := os.FileMode(0o600)
+
+		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/input_%d_%s.tagged.pb", indir, i, r.ToolName), encodedProto, rwPermission600))
+	}
+
+	svr := setupRegoServer(t)
+	defer svr.Close()
+
+	// Launch the enricher
+	regoServer = svr.URL
+	enrichers.SetReadPathForTests(indir)
+	enrichers.SetWritePathForTests(outdir)
+	policy = defaultPolicy
+
+	require.NoError(t, run())
+
+	// Check there is something in our output directory
+	files, err := os.ReadDir(outdir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, files)
+	assert.Len(t, files, 2)
+
+	// Check that both of them are EnrichedLaunchToolResponse
+	// and their Issue property is an empty list
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".raw.pb") {
+			continue
+		}
+
+		encodedProto, err := os.ReadFile(fmt.Sprintf("%s/%s", outdir, f.Name()))
+		require.NoError(t, err)
+
+		output := &v1.EnrichedLaunchToolResponse{}
+		require.NoError(t, proto.Unmarshal(encodedProto, output))
+
+		assert.Empty(t, output.Issues)
 	}
 }

--- a/components/enrichers/test_utils.go
+++ b/components/enrichers/test_utils.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"testing"
 
-	v1 "github.com/ocurity/dracon/api/proto/v1"
 	"github.com/stretchr/testify/require"
+
+	draconv1 "github.com/ocurity/dracon/api/proto/v1"
 )
 
+// SetupIODirs creates temporary directories for input and output files
 func SetupIODirs(t *testing.T) (indir, outdir string) {
 	indir, err := os.MkdirTemp("/tmp", "")
 	require.NoError(t, err)
@@ -18,15 +20,16 @@ func SetupIODirs(t *testing.T) (indir, outdir string) {
 	return indir, outdir
 }
 
-func GetEmptyLaunchToolResponse(t *testing.T) []*v1.LaunchToolResponse {
-	return []*v1.LaunchToolResponse{
+// GetEmptyLaunchToolResponse returns a slice of LaunchToolResponse with no issues
+func GetEmptyLaunchToolResponse(_ *testing.T) []*draconv1.LaunchToolResponse {
+	return []*draconv1.LaunchToolResponse{
 		{
 			ToolName: "tool1",
-			Issues:   []*v1.Issue{},
+			Issues:   []*draconv1.Issue{},
 		},
 		{
 			ToolName: "tool2",
-			Issues:   []*v1.Issue{},
+			Issues:   []*draconv1.Issue{},
 		},
 	}
 }

--- a/components/enrichers/test_utils.go
+++ b/components/enrichers/test_utils.go
@@ -1,0 +1,32 @@
+package enrichers
+
+import (
+	"os"
+	"testing"
+
+	v1 "github.com/ocurity/dracon/api/proto/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func SetupIODirs(t *testing.T) (indir, outdir string) {
+	indir, err := os.MkdirTemp("/tmp", "")
+	require.NoError(t, err)
+
+	outdir, err = os.MkdirTemp("/tmp", "")
+	require.NoError(t, err)
+
+	return indir, outdir
+}
+
+func GetEmptyLaunchToolResponse(t *testing.T) []*v1.LaunchToolResponse {
+	return []*v1.LaunchToolResponse{
+		{
+			ToolName: "tool1",
+			Issues:   []*v1.Issue{},
+		},
+		{
+			ToolName: "tool2",
+			Issues:   []*v1.Issue{},
+		},
+	}
+}

--- a/components/producers/producer_test.go
+++ b/components/producers/producer_test.go
@@ -21,6 +21,27 @@ type testJ struct {
 	Foo string
 }
 
+func TestWriteDraconOutEmpty(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "dracon-test")
+	require.NoError(t, err)
+	defer require.NoError(t, os.Remove(tmpFile.Name()))
+
+	OutFile = tmpFile.Name()
+	Append = false
+
+	err = WriteDraconOut("dracon-test", nil)
+	require.NoError(t, err)
+
+	pBytes, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	res := v1.LaunchToolResponse{}
+	require.NoError(t, proto.Unmarshal(pBytes, &res))
+
+	assert.Equal(t, "dracon-test", res.GetToolName())
+	assert.Equal(t, 0, len(res.GetIssues()))
+}
+
 func TestWriteDraconOut(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "dracon-test")
 	require.NoError(t, err)


### PR DESCRIPTION
Via OCU-104 we discovered that the `enricher-aggregator` component crashes if no issues were enriched. This is a bug. It shouldn't crash, it should simply produce an aggregated output with no findings.

In this PR, we ensure all existing enricher components always produce a result. If there were no issues supplied to the respective enrichers we simply store an empty list result.

 We also add tests for this behaviour to all enrichers.