### PR TITLE
fix for GH publish action Helm package path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           helm package --dependency-update \
                        --app-version ${{ github.ref_name }} \
                        --version ${DRACON_VERSION_SEMVER} \
-                       ./deploy/enrichment-db-migrations/chart
+                       ./deploy/deduplication-db-migrations/chart
           helm push enrichment-db-migrations-${DRACON_VERSION_SEMVER}.tgz oci://ghcr.io/ocurity/dracon/charts
 
           make cmd/draconctl/bin


### PR DESCRIPTION
You can see the error over here: https://github.com/ocurity/dracon/actions/runs/9976308431/job/27568157322