### PR TITLE
[OCU-155] Fix example workflows are failing

### DIFF
--- a/components/consumers/elasticsearch/task.yaml
+++ b/components/consumers/elasticsearch/task.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     - name: consumer-elasticsearch-url
       type: string
-      default: "http://dracon-es-elasticsearch-es-http:9200"
+      default: "http://dracon-es-http.dracon.svc.cluster.local:9200"
     - name: consumer-elasticsearch-description-template
       type: string
       default: ""

--- a/components/consumers/elasticsearch/task.yaml
+++ b/components/consumers/elasticsearch/task.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     - name: consumer-elasticsearch-url
       type: string
-      default: "http://dracon-es-http.dracon.svc.cluster.local:9200"
+      default: "http://dracon-es-http:9200"
     - name: consumer-elasticsearch-description-template
       type: string
       default: ""

--- a/components/consumers/mongodb/task.yaml
+++ b/components/consumers/mongodb/task.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     - name: consumer-mongodb-db-uri
       type: string
-      default: "mongodb://consumer-mongodb:consumer-mongodb@consumer-mongodb:27017/consumer-mongodb"
+      default: "mongodb://consumer-mongodb:consumer-mongodb@dracon-mongodb.dracon.svc.cluster.local:27017/consumer-mongodb"
     - name: consumer-mongodb-db-name
       type: string
       default: "consumer-mongodb"

--- a/components/consumers/mongodb/task.yaml
+++ b/components/consumers/mongodb/task.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     - name: consumer-mongodb-db-uri
       type: string
-      default: "mongodb://consumer-mongodb:consumer-mongodb@dracon-mongodb.dracon.svc.cluster.local:27017/consumer-mongodb"
+      default: "mongodb://consumer-mongodb:consumer-mongodb@dracon-mongodb:27017/consumer-mongodb"
     - name: consumer-mongodb-db-name
       type: string
       default: "consumer-mongodb"

--- a/components/enrichers/codeowners/main.go
+++ b/components/enrichers/codeowners/main.go
@@ -81,10 +81,13 @@ func run() error {
 			enrichedIssues = append(enrichedIssues, eI)
 		}
 
-		return enrichers.WriteData(&apiv1.EnrichedLaunchToolResponse{
+		err := enrichers.WriteData(&apiv1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,
 		}, "codeowners")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/enrichers/codeowners/main_test.go
+++ b/components/enrichers/codeowners/main_test.go
@@ -36,7 +36,7 @@ func TestHandlesZeroFindings(t *testing.T) {
 	files, err := os.ReadDir(outdir)
 	require.NoError(t, err)
 	assert.NotEmpty(t, files)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 4)
 
 	// Check that both of them are EnrichedLaunchToolResponse
 	// and their Issue property is an empty list

--- a/components/enrichers/deduplication/main.go
+++ b/components/enrichers/deduplication/main.go
@@ -53,10 +53,13 @@ func run() error {
 			enrichedIssues = append(enrichedIssues, eI)
 			log.Printf("enriched issue '%s'", eI.GetRawIssue().GetUuid())
 		}
-		return enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
+		err := enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,
 		}, "deduplication")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/enrichers/deduplication/main_test.go
+++ b/components/enrichers/deduplication/main_test.go
@@ -49,7 +49,7 @@ func TestHandlesZeroFindings(t *testing.T) {
 	files, err := os.ReadDir(outdir)
 	require.NoError(t, err)
 	assert.NotEmpty(t, files)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 4)
 
 	// Check that both of them are EnrichedLaunchToolResponse
 	// and their Issue property is an empty list

--- a/components/enrichers/depsdev/main.go
+++ b/components/enrichers/depsdev/main.go
@@ -215,10 +215,13 @@ func run() error {
 			enrichedIssues = append(enrichedIssues, eI)
 		}
 
-		return enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
+		err := enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,
 		}, "deps-dev")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/enrichers/policy/main.go
+++ b/components/enrichers/policy/main.go
@@ -79,10 +79,13 @@ func run() error {
 			enrichedIssues = append(enrichedIssues, eI)
 		}
 
-		return enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
+		err := enrichers.WriteData(&v1.EnrichedLaunchToolResponse{
 			OriginalResults: r,
 			Issues:          enrichedIssues,
 		}, "policy")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/enrichers/policy/main_test.go
+++ b/components/enrichers/policy/main_test.go
@@ -157,7 +157,7 @@ func TestHandlesZeroFindings(t *testing.T) {
 	files, err := os.ReadDir(outdir)
 	require.NoError(t, err)
 	assert.NotEmpty(t, files)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 4)
 
 	// Check that both of them are EnrichedLaunchToolResponse
 	// and their Issue property is an empty list

--- a/components/producers/semgrep/task.yaml
+++ b/components/producers/semgrep/task.yaml
@@ -22,7 +22,7 @@ spec:
       description: The workspace containing the source-code to scan.
   steps:
   - name: write-semgrep-config
-    image: docker.io/busybox:latest
+    image: docker.io/library/busybox:1.36
     env:
       - name: SEMGREP_CONFIG
         value: $(params.producer-semgrep-rules-yaml)
@@ -34,10 +34,9 @@ spec:
       name: scratch
 
   - name: run-semgrep
-    image: docker.io/returntocorp/semgrep:1.11.0
-    command: [/entrypoint.sh]
+    image: docker.io/returntocorp/semgrep:1.80
+    command: ["semgrep"]
     args:
-    - "semgrep"
     - "scan"
     - "--config"
     - "/scratch/semgrep-rules.yaml"

--- a/components/producers/typescript-eslint/task.yaml
+++ b/components/producers/typescript-eslint/task.yaml
@@ -18,7 +18,7 @@ spec:
       description: The workspace containing the source-code to scan.
   steps:
   - name: run-eslint
-    image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-eslint/eslint-wrapper/eslint:latest'
+    image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-eslint:latest'
     command: ["/home/node/workspace/eslint-wrapper"]
     args:
      - -t

--- a/components/producers/typescript-eslint/task.yaml
+++ b/components/producers/typescript-eslint/task.yaml
@@ -18,7 +18,7 @@ spec:
       description: The workspace containing the source-code to scan.
   steps:
   - name: run-eslint
-    image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-eslint:latest'
+    image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-eslint/eslint-wrapper/eslint:latest'
     command: ["/home/node/workspace/eslint-wrapper"]
     args:
      - -t

--- a/components/producers/typescript-yarn-audit/main.go
+++ b/components/producers/typescript-yarn-audit/main.go
@@ -24,12 +24,7 @@ func main() {
 
 	// Individual errors should already be printed to logs
 	if len(errors) > 0 {
-		errorMessage := "Errors creating Yarn Audit report: %d"
-		if report != nil {
-			log.Printf(errorMessage, len(errors))
-		} else {
-			log.Fatalf(errorMessage, len(errors))
-		}
+		log.Fatalf("Errors creating Yarn Audit report: %d", len(errors))
 	}
 
 	if report != nil {

--- a/components/producers/typescript-yarn-audit/task.yaml
+++ b/components/producers/typescript-yarn-audit/task.yaml
@@ -19,19 +19,21 @@ spec:
       image: docker.io/node:lts
       script: |
         cd $(workspaces.output.path)
+        echo "Starting yarn audit command..."
         yarn audit --json --silent --no-progress > /scratch/out.json || true
+        echo "Done"
       volumeMounts:
         - mountPath: /scratch
           name: scratch
 
     - name: produce-issues
       imagePullPolicy: IfNotPresent
-      image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-eslint:latest'
+      image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/typescript-yarn-audit:latest'
       command:
-        ["/app/components/producers/typescript-yarn-audit/yarn-audit-parser"]
+        ["/app/components/producers/typescript-yarn-audit/typescript-yarn-audit-parser"]
       args:
         - "-in=/scratch/out.json"
-        - "-out=$(workspaces.output.path)/.dracon/producers/typescript-eslint.pb"
+        - "-out=$(workspaces.output.path)/.dracon/producers/typescript-yarn-audit.pb"
       volumeMounts:
         - mountPath: /scratch
           name: scratch

--- a/components/producers/typescript-yarn-audit/types/yarn-issue_test.go
+++ b/components/producers/typescript-yarn-audit/types/yarn-issue_test.go
@@ -6,7 +6,7 @@ import (
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var invalidJSON = `Not a valid JSON object`
@@ -18,9 +18,9 @@ func TestParseInvalidJSON(t *testing.T) {
 		oneLine,
 	})
 
-	assert.Nil(t, report)
+	require.Nil(t, report)
 
-	assert.Len(t, err, 2)
+	require.Len(t, err, 2)
 }
 
 // In reality these would be single lines, but for readability in test these should also work.
@@ -193,12 +193,12 @@ func TestParseValidReportContainsAllSupportedFields(t *testing.T) {
 		fullYarnJSONLines,
 	)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, report)
+	require.Nil(t, err)
+	require.NotNil(t, report)
 
-	assert.NotNil(t, report.AuditSummary)
-	assert.Len(t, report.AuditAdvisories, 2)
-	assert.Len(t, report.AuditActions, 1)
+	require.NotNil(t, report.AuditSummary)
+	require.Len(t, report.AuditAdvisories, 2)
+	require.Len(t, report.AuditActions, 1)
 }
 
 func TestParseValidReportSummary(t *testing.T) {
@@ -206,10 +206,10 @@ func TestParseValidReportSummary(t *testing.T) {
 		fullYarnJSONLines,
 	)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, report)
+	require.Nil(t, err)
+	require.NotNil(t, report)
 
-	assert.NotNil(t, report.AuditSummary)
+	require.NotNil(t, report.AuditSummary)
 
 	expectedSummaryData := auditSummaryData{
 		Vulnerabilities: vulnerabilities{
@@ -225,7 +225,7 @@ func TestParseValidReportSummary(t *testing.T) {
 		TotalDependencies:    6274,
 	}
 
-	assert.True(t, reflect.DeepEqual(&expectedSummaryData, report.AuditSummary), report.AuditSummary)
+	require.True(t, reflect.DeepEqual(&expectedSummaryData, report.AuditSummary), report.AuditSummary)
 }
 
 func TestParseValidReportAdvisories(t *testing.T) {
@@ -233,10 +233,10 @@ func TestParseValidReportAdvisories(t *testing.T) {
 		fullYarnJSONLines,
 	)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, report)
+	require.Nil(t, err)
+	require.NotNil(t, report)
 
-	assert.Len(t, report.AuditAdvisories, 2)
+	require.Len(t, report.AuditAdvisories, 2)
 
 	expectedAdvisories := []*auditAdvisoryData{
 		{
@@ -339,7 +339,7 @@ func TestParseValidReportAdvisories(t *testing.T) {
 		},
 	}
 
-	assert.True(t, reflect.DeepEqual(expectedAdvisories, report.AuditAdvisories), report.AuditAdvisories)
+	require.True(t, reflect.DeepEqual(expectedAdvisories, report.AuditAdvisories), report.AuditAdvisories)
 }
 
 func TestParseValidReportActions(t *testing.T) {
@@ -347,10 +347,10 @@ func TestParseValidReportActions(t *testing.T) {
 		fullYarnJSONLines,
 	)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, report)
+	require.Nil(t, err)
+	require.NotNil(t, report)
 
-	assert.Len(t, report.AuditActions, 1)
+	require.Len(t, report.AuditActions, 1)
 
 	expectedActionData := auditActionData{
 		Cmd:        "action command",
@@ -372,7 +372,7 @@ func TestParseValidReportActions(t *testing.T) {
 		},
 	}
 
-	assert.True(t, reflect.DeepEqual(&expectedActionData, report.AuditActions[0]), report.AuditActions[0])
+	require.True(t, reflect.DeepEqual(&expectedActionData, report.AuditActions[0]), report.AuditActions[0])
 }
 
 func TestParseValidReportAsIssues(t *testing.T) {
@@ -380,12 +380,12 @@ func TestParseValidReportAsIssues(t *testing.T) {
 		fullYarnJSONLines,
 	)
 
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Len(t, report.AuditAdvisories, 2)
+	require.Len(t, report.AuditAdvisories, 2)
 
 	issues := report.AsIssues()
-	assert.Len(t, issues, 2)
+	require.Len(t, issues, 2)
 
 	expectedIssues := []*v1.Issue{
 		{
@@ -426,15 +426,15 @@ Advisory URL: https://advisory.2.url
 	}
 
 	for i := range expectedIssues {
-		assert.Equal(t, expectedIssues[i].Target, issues[i].Target)
-		assert.Equal(t, expectedIssues[i].Type, issues[i].Type)
-		assert.Equal(t, expectedIssues[i].Title, issues[i].Title)
-		assert.Equal(t, expectedIssues[i].Severity, issues[i].Severity)
-		assert.Equal(t, expectedIssues[i].Cvss, issues[i].Cvss)
-		assert.Equal(t, expectedIssues[i].Confidence, issues[i].Confidence)
-		assert.Equal(t, expectedIssues[i].Description, issues[i].Description)
-		assert.Equal(t, expectedIssues[i].Cve, issues[i].Cve)
-		assert.Equal(t, expectedIssues[i].Cwe, issues[i].Cwe)
+		require.Equal(t, expectedIssues[i].Target, issues[i].Target)
+		require.Equal(t, expectedIssues[i].Type, issues[i].Type)
+		require.Equal(t, expectedIssues[i].Title, issues[i].Title)
+		require.Equal(t, expectedIssues[i].Severity, issues[i].Severity)
+		require.Equal(t, expectedIssues[i].Cvss, issues[i].Cvss)
+		require.Equal(t, expectedIssues[i].Confidence, issues[i].Confidence)
+		require.Equal(t, expectedIssues[i].Description, issues[i].Description)
+		require.Equal(t, expectedIssues[i].Cve, issues[i].Cve)
+		require.Equal(t, expectedIssues[i].Cwe, issues[i].Cwe)
 	}
 }
 
@@ -446,8 +446,8 @@ func TestHandlesNoDependencies(t *testing.T) {
 
 	report, errs := NewReport(missingDependenciesReport)
 
-	assert.Empty(t, report)
-	assert.Len(t, errs, 1)
-	assert.Equal(t, errs[0].Error(), "no dependencies found")
+	require.Empty(t, report)
+	require.Len(t, errs, 1)
+	require.Equal(t, errs[0].Error(), "no dependencies found")
 
 }

--- a/components/producers/typescript-yarn-audit/types/yarn-issue_test.go
+++ b/components/producers/typescript-yarn-audit/types/yarn-issue_test.go
@@ -437,3 +437,17 @@ Advisory URL: https://advisory.2.url
 		assert.Equal(t, expectedIssues[i].Cwe, issues[i].Cwe)
 	}
 }
+
+func TestHandlesNoDependencies(t *testing.T) {
+	missingDependenciesReport := [][]byte{
+		[]byte(`{"type":"info","data":"No lockfile found."}`),
+		[]byte(`{"type":"auditSummary","data":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0},"dependencies":0,"devDependencies":0,"optionalDependencies":0,"totalDependencies":0}}`),
+	}
+
+	report, errs := NewReport(missingDependenciesReport)
+
+	assert.Empty(t, report)
+	assert.Len(t, errs, 1)
+	assert.Equal(t, errs[0].Error(), "no dependencies found")
+
+}

--- a/examples/pipelines/golang-project/kustomization.yaml
+++ b/examples/pipelines/golang-project/kustomization.yaml
@@ -8,7 +8,7 @@ components:
   - pkg:helm/dracon-oss-components/producer-golang-gosec
   - pkg:helm/dracon-oss-components/producer-golang-nancy
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-deduplication
+  - pkg:helm/dracon-oss-components/enricher-codeowners
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb
   - pkg:helm/dracon-oss-components/consumer-elasticsearch

--- a/examples/pipelines/golang-project/pipelinerun.yaml
+++ b/examples/pipelines/golang-project/pipelinerun.yaml
@@ -11,14 +11,6 @@ spec:
     value: https://github.com/ocurity/e2e-monorepo.git
   - name: git-clone-subdirectory
     value: source-code
-  - name: enricher-aggregator-b64-signature-key
-  # THIS IS AN EXAMPLE, PLEASE USE A PROPERLY SECURED SECRET KEY IN PRODUCTION
-  # Corresponding public key for verification is MOt7TFuLyGB9yRN5mcIeAPa6jKoFglkwEwGBTOVLeXI=
-    value: Lvbo+wAsW8Y4ENBA+lAikOwGTYAIXCQ49eRMEwClv94w63tMW4vIYH3JE3mZwh4A9rqMqgWCWTATAYFM5Ut5cg==
-  - name: consumer-elasticsearch-url
-    value: http://dracon-es-http:9200
-  - name: consumer-mongodb-db-uri
-    value: mongodb://consumer-mongodb:consumer-mongodb@dracon-mongodb:27017/consumer-mongodb
   workspaces:
   - name: output
     volumeClaimTemplate:

--- a/examples/pipelines/python-project/kustomization.yaml
+++ b/examples/pipelines/python-project/kustomization.yaml
@@ -8,7 +8,7 @@ components:
   - pkg:helm/dracon-oss-components/producer-python-bandit
   - pkg:helm/dracon-oss-components/producer-python-pip-safety
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-deduplication
+  - pkg:helm/dracon-oss-components/enricher-codeowners
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb
   - pkg:helm/dracon-oss-components/consumer-elasticsearch

--- a/examples/pipelines/python-project/pipelinerun.yaml
+++ b/examples/pipelines/python-project/pipelinerun.yaml
@@ -9,11 +9,7 @@ spec:
     name: dracon-python-project
   params:
   - name: git-clone-url
-    value: https://github.com/ocurity/dracon.git
-  - name: b64-signature-key
-  # THIS IS AN EXAMPLE, PLEASE USE A PROPERLY SECURED SECRET KEY IN PRODUCTION
-  # Corresponding public key for verification is MOt7TFuLyGB9yRN5mcIeAPa6jKoFglkwEwGBTOVLeXI=
-    value: Lvbo+wAsW8Y4ENBA+lAikOwGTYAIXCQ49eRMEwClv94w63tMW4vIYH3JE3mZwh4A9rqMqgWCWTATAYFM5Ut5cg==
+    value: https://github.com/ocurity/e2e-monorepo.git
   workspaces:
   - name: output
     subPath: source-code

--- a/examples/pipelines/typescript-project/kustomization.yaml
+++ b/examples/pipelines/typescript-project/kustomization.yaml
@@ -6,7 +6,7 @@ components:
   - pkg:helm/dracon-oss-components/base
   - pkg:helm/dracon-oss-components/git-clone
   - pkg:helm/dracon-oss-components/producer-typescript-yarn-audit
-  - pkg:helm/dracon-oss-components/producer-typescript-eslint
+  - pkg:helm/dracon-oss-components/producer-semgrep
   - pkg:helm/dracon-oss-components/producer-aggregator
   - pkg:helm/dracon-oss-components/enricher-codeowners
   - pkg:helm/dracon-oss-components/enricher-aggregator

--- a/examples/pipelines/typescript-project/kustomization.yaml
+++ b/examples/pipelines/typescript-project/kustomization.yaml
@@ -8,7 +8,7 @@ components:
   - pkg:helm/dracon-oss-components/producer-typescript-yarn-audit
   - pkg:helm/dracon-oss-components/producer-typescript-eslint
   - pkg:helm/dracon-oss-components/producer-aggregator
-  - pkg:helm/dracon-oss-components/enricher-deduplication
+  - pkg:helm/dracon-oss-components/enricher-codeowners
   - pkg:helm/dracon-oss-components/enricher-aggregator
   - pkg:helm/dracon-oss-components/consumer-mongodb
   - pkg:helm/dracon-oss-components/consumer-elasticsearch

--- a/examples/pipelines/typescript-project/pipelinerun.yaml
+++ b/examples/pipelines/typescript-project/pipelinerun.yaml
@@ -9,7 +9,8 @@ spec:
     name: dracon-typescript-project
   params:
   - name: git-clone-url
-    value: https://github.com/ocurity/e2e-monorepo.git
+    # TODO(OCU-154): Switch to ocurity/e2e-monorepo
+    value: https://github.com/appsecco/dvna.git
   workspaces:
   - name: output
     subPath: source-code

--- a/examples/pipelines/typescript-project/pipelinerun.yaml
+++ b/examples/pipelines/typescript-project/pipelinerun.yaml
@@ -8,12 +8,8 @@ spec:
   pipelineRef:
     name: dracon-typescript-project
   params:
-  - name: repository_url
+  - name: git-clone-url
     value: https://github.com/ocurity/e2e-monorepo.git
-  - name: b64-signature-key
-  # THIS IS AN EXAMPLE, PLEASE USE A PROPERLY SECURED SECRET KEY IN PRODUCTION
-  # Corresponding public key for verification is MOt7TFuLyGB9yRN5mcIeAPa6jKoFglkwEwGBTOVLeXI=
-    value: Lvbo+wAsW8Y4ENBA+lAikOwGTYAIXCQ49eRMEwClv94w63tMW4vIYH3JE3mZwh4A9rqMqgWCWTATAYFM5Ut5cg==
   workspaces:
   - name: output
     subPath: source-code


### PR DESCRIPTION
This PR fixes three existing example workflows, so they run successfully and produce valid results.

![image](https://github.com/user-attachments/assets/827be996-0eef-45fa-9b9a-11ad1e6ead26)

We now have three example pipelines (golang, typescript, python) that all produce useful results. To achieve this, several things were changed.

## Config Changes
- 🔧 Change default ES and MongoDB URLs: They were referencing nonexistent instances
- 🔧 Replace enricher-deduplication with enricher-codeowners: De-duplication is broken atm, Spyros is working on a fix
- 🔧 Change example golang pipeline: Referenced a few params that aren't needed
- 🔧 Change example python pipeline: Also referenced a few params that aren't needed

## Bug Fixes
- 🐛 Fix incorrect parameter name in TS example pipeline: Was referencing a nonexistent parameter
- 🐛 Fix producer/yarn-audit not handling empty lines: The input file is a very weird JSON, sometimes it has empty lines, we crashed previously
- 🐛 Fix erroneous image reference in eslint producer: The image didn't exist
- 🐛 Fix producer/eslint component not starting
- 🐛 Fix producer/semgrep fails to run
- 🐛 Fix typescript example workflow
- 🐛 Fix enrichers not handling multiple tools

## Misc
- 🔨 Add utility script to bump local components
- ♻️ Refactor image pinning test