### PR TITLE
Improve Go Test Runner

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: Format
 on:
   pull_request:
     branches:
-    - main
+      - main
 
 permissions:
   # Grant the ability to checkout the repository
@@ -17,13 +17,13 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Setup Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Format
-      run: make install-go-fmt-tools install-md-fmt-tools fmt && test $(git diff -p | wc -l) -eq 0
+      - name: Format
+        run: make install-go-fmt-tools install-md-fmt-tools fmt && test $(git diff -p | wc -l) -eq 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,11 @@ name: Lint
 on:
   pull_request_target:
     types:
-    - opened
-    - synchronize
-    - reopened
+      - opened
+      - synchronize
+      - reopened
     branches:
-    - main
+      - main
 
 permissions:
   # Grant the ability to checkout the repository
@@ -23,24 +23,24 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Setup Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Setup node
-      uses: actions/setup-node@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
 
-    - name: Setup reviewdog
-      run: go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
+      - name: Setup reviewdog
+        run: go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
 
-    - name: Install linters
-      run: make install-lint-tools
+      - name: Install linters
+        run: make install-lint-tools
 
-    - name: Lint
-      env:
-        REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      run: make lint
+      - name: Lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 permissions:
   # Grant the ability to checkout the repository
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+
+      - name: Install Go Test Tools
+        run: make install-go-test-tools
 
       - name: Run Go tests
         run: make go-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           format: golang
           file: tests/output/cover.out
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "tests/output/*-tests.xml"
+        if: always()

--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,12 @@ install-lint-tools:
 	@go install github.com/bufbuild/buf/cmd/buf@v1.32.2
 	@npm ci
 
+install-go-test-tools:
+	@go install gotest.tools/gotestsum@latest
+
 go-tests:
 	@mkdir -p tests/output
-	@go test -race -json -coverprofile tests/output/cover.out $(GO_TEST_PACKAGES)
+	@gotestsum --junitfile tests/output/unit-tests.xml -- -race -coverprofile tests/output/cover.out $(GO_TEST_PACKAGES)
 
 go-cover: go-tests
 	@go tool cover -html=tests/output/cover.out -o=tests/output/cover.html && open tests/output/cover.html


### PR DESCRIPTION
This PR improves the golang test runner, both in CI but also locally. In particular, it does these three things to achieve that:

### 👷 Replace `go test` with `gotestsum`
Previously our test output was only in JSON - easy to read for a machine, harder to read for a human.
The `gotestsum` package is a drop-in replacement for `go test` and [very widely used](https://github.com/gotestyourself/gotestsum?tab=readme-ov-file#who-uses-gotestsum) (e.g. by kubernetes).

Three main improvements it brings are:
1. Change the [test output format](https://github.com/gotestyourself/gotestsum?tab=readme-ov-file#output-format), from compact to verbose with color highlighting.
2. Print a [summary](https://github.com/gotestyourself/gotestsum?tab=readme-ov-file#summary) of the test run after running all the tests.
3. write a JUnit XML file for integration with CI systems (used for test summary below)

![example test output](https://github.com/user-attachments/assets/b9933f0f-b236-4e4d-a391-d3caf5a5425a)



### 👷 Add test summary for Go tests
GitHub previously introduced job summaries, which among other things, provides richer information like shown below rather than just a simple `pass/fail`. We are now exporting that information to GHA as well.
![img](https://camo.githubusercontent.com/a0db8c4d25ed2c7665f30da1112831dbee54e4fc547631e1ea71c47a51e93783/68747470733a2f2f7376672e746573742d73756d6d6172792e636f6d2f64617368626f6172642e7376673f703d343226663d3826733d3138)

### ⬆️ Bump `actions/setup-go@v4` to `v5`
Previously we kept getting this deprecation warning, which is [further explained here](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default). By bumping the action to `v5` that's resolved.
![image](https://github.com/user-attachments/assets/e67602d4-57ce-4b32-b2d8-76ae391d4fbf)

