### PR TITLE
Fix Slack Consumer

### DIFF
--- a/components/consumers/slack/Dockerfile
+++ b/components/consumers/slack/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY ./components/consumers/slack/slack /app/components/consumers/slack/slack
+
+ENTRYPOINT ["/app/components/consumers/slack/slack"]

--- a/components/consumers/slack/Makefile
+++ b/components/consumers/slack/Makefile
@@ -1,0 +1,17 @@
+.PHONY: container publish
+
+CONTAINER_REPO=
+DRACON_VERSION=
+SOURCE_CODE_REPO=
+PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+
+DOCKER=docker
+
+container:
+	$(DOCKER) build --tag $(CONTAINER_REPO)/components/consumers/slack:$(DRACON_VERSION) \
+					--file Dockerfile \
+					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
+					 ../../../bin 1>&2
+
+publish:
+	$(DOCKER) push $(CONTAINER_REPO)/components/consumers/slack:$(DRACON_VERSION) 1>&2

--- a/components/consumers/slack/task.yaml
+++ b/components/consumers/slack/task.yaml
@@ -8,9 +8,11 @@ metadata:
 spec:
   params:
     - name: consumer-slack-webhook
+      description: "The Slack webhook to send messages to. Follow this guide to generate: https://api.slack.com/messaging/webhooks"
       type: string
     - name: consumer-slack-message-template
       type: string
+      description: "The message template to use when sending messages to Slack. The following variables are available: <scanID>, <scanStartTime>, <numResults>, <newResults>"
       default: 'Dracon scan <scanID>, started at <scanStartTime>, completed with <numResults> findings, out of which, <newResults> new'
   workspaces:
     - name: output


### PR DESCRIPTION
This PR fixes the Slack consumer. It previously failed to make requests to the Slack API.

### Issue Description

Running the Slack consumer as part of a pipeline, it failed with the below error message:

> could not push metrics: Post \"[https://hooks.slack.com/services/XXX/XXX/XXX\](https://hooks.slack.com/services/XXX/XXX/XXX/)": tls: failed to verify certificate: x509: **certificate signed by unknown authority**

This is because the default docker image uses `scratch` as it's base, which doesn't come with CAs.
We are resolving that by instead using an `alpine` image as the base, with added `ca-certificates`.

![image](https://github.com/user-attachments/assets/73e2f5cc-014e-4022-b7ba-3e56cee0e605)
