### PR TITLE
Fix `producers/docker-trivy` Component

### DIFF
--- a/components/producers/docker-trivy/task.yaml
+++ b/components/producers/docker-trivy/task.yaml
@@ -26,7 +26,7 @@ spec:
       description: The workspace containing the source-code to scan.
   steps:
   - name: run-trivy
-    image: docker.io/aquasec/trivy:0.37.1
+    image: docker.io/aquasec/trivy:0.54.1
     command: [trivy]
     args:
     - "$(params.producer-docker-trivy-flags[*])"

--- a/components/producers/docker-trivy/task.yaml
+++ b/components/producers/docker-trivy/task.yaml
@@ -30,7 +30,6 @@ spec:
     command: [trivy]
     args:
     - "$(params.producer-docker-trivy-flags[*])"
-    - -q
     - -f
     - $(params.producer-docker-trivy-format)
     - -o

--- a/components/producers/docker-trivy/task.yaml
+++ b/components/producers/docker-trivy/task.yaml
@@ -44,7 +44,7 @@ spec:
   - name: produce-issues
     imagePullPolicy: IfNotPresent
     image: '{{ default "ghcr.io/ocurity/dracon" .Values.container_registry }}/components/producers/docker-trivy:latest'
-    command: ["/app/components/producers/docker-trivy/trivy-parser"]
+    command: ["/app/components/producers/docker-trivy/docker-trivy-parser"]
     args:
     - "-format=$(params.producer-docker-trivy-format)"
     - "-in=/scratch/out.json"

--- a/components/producers/docker-trivy/task.yaml
+++ b/components/producers/docker-trivy/task.yaml
@@ -11,13 +11,19 @@ spec:
   - name: producer-docker-trivy-flags
     type: array
     default: []
+    description: Flags to pass to trivy. Optional.
   - name: producer-docker-trivy-target
     type: string
     default: "$(workspaces.output.path)"
+    description: The target to scan.
   - name: producer-docker-trivy-format
     type: string
+    default: json
+    description: The format to output the results in. Valid values are `json`, `sarif`, `cyclonedx`. Default `json`.
   - name: producer-docker-trivy-command
     type: string
+    default: image
+    description: The command to run trivy with. Default `image`.
   volumes:
     - name: scratch
       emptyDir: {}

--- a/components/producers/producer.go
+++ b/components/producers/producer.go
@@ -118,7 +118,7 @@ func WriteDraconOut(
 	scanTags := map[string]string{}
 	err = json.Unmarshal([]byte(scanTagsStr), &scanTags)
 	if err != nil {
-		slog.Error(fmt.Sprintf("scan does not have any tags, err:%s", err))
+		slog.Debug("scan does not have any tags", "err", err)
 	}
 
 	stat, err := os.Stat(OutFile)

--- a/examples/pipelines/sca-project/kustomization.yaml
+++ b/examples/pipelines/sca-project/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -sca-project
+components:
+  - pkg:helm/dracon-oss-components/base
+  - pkg:helm/dracon-oss-components/producer-docker-trivy
+  - pkg:helm/dracon-oss-components/producer-aggregator
+  - pkg:helm/dracon-oss-components/enricher-codeowners
+  - pkg:helm/dracon-oss-components/enricher-aggregator
+  - pkg:helm/dracon-oss-components/consumer-mongodb
+  - pkg:helm/dracon-oss-components/consumer-elasticsearch

--- a/examples/pipelines/sca-project/pipelinerun.yaml
+++ b/examples/pipelines/sca-project/pipelinerun.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: dracon-sca-project-
+  namespace: dracon
+spec:
+  pipelineRef:
+    name: dracon-sca-project
+  params:
+  - name: producer-docker-trivy-target
+    value: python:3.4-alpine
+  workspaces:
+  - name: output
+    subPath: source-code
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
The component previously didn't run. Now it does.

Also adding an example workflow for a SCA usecase.