### PR TITLE
make oss migrations run as part of dev-dracon

### DIFF
--- a/components/enrichers/deduplication/task.yaml
+++ b/components/enrichers/deduplication/task.yaml
@@ -20,4 +20,4 @@ spec:
     - name: ENRICHER_WRITE_PATH
       value: "$(workspaces.output.path)/.dracon/enrichers/deduplication"
     - name: ENRICHER_DB_CONNECTION
-      value: postgresql://{{default "dracon" .Values.postgresql.auth.username }}:{{default "dracon" .Values.postgresql.auth.password }}@{{ default "dracon-enrichment-db" .Values.postgresql.host }}/{{default "dracon" .Values.postgresql.auth.database }}?{{default "sslmode=disable" .Values.postgresql.auth.querystringargs}}
+      value: postgresql://{{.Values.database.auth.username}}:{{.Values.database.auth.password}}@{{.Values.database.host}}/{{.Values.database.auth.database}}?{{.Values.database.auth.querystringargs}}"

--- a/deploy/deduplication-db-migrations/chart/templates/migrations-job.yaml
+++ b/deploy/deduplication-db-migrations/chart/templates/migrations-job.yaml
@@ -20,6 +20,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: enrichment-db-migrations
+        # image.tag is set because you can't do helm upgrade and set the chart AppVersion manually
         image: "{{ default "ghcr.io/ocurity/dracon" .Values.image.registry }}/draconctl:{{ default .Chart.AppVersion .Values.image.tag }}"
         env:
           - name: DRACONCTL_MIGRATIONS_PATH

--- a/deploy/deduplication-db-migrations/chart/values.yaml
+++ b/deploy/deduplication-db-migrations/chart/values.yaml
@@ -2,10 +2,11 @@
 # the database should use the Postgres dialect.
 
 # image to use for applying the migrations
-global:
-  image:
-    # registry to use for all 
-    registry: ""
+image:
+  # registry to use for all 
+  registry: ""
 
 serviceAccount:
   create: false
+
+enabled: true

--- a/deploy/deduplication-db-migrations/values/dev.yaml
+++ b/deploy/deduplication-db-migrations/values/dev.yaml
@@ -1,4 +1,12 @@
 
-global:
-  image:
-    registry: kind-registry:5000
+image:
+  registry: kind-registry:5000
+
+database:
+  auth:
+    username: dracon
+    password: dracon
+    database: dracon
+    postgresPassword: dracon
+    querystringargs: "sslmode=disable"
+  host: dracon-postgresql:5432

--- a/deploy/dracon/chart/Chart.lock
+++ b/deploy/dracon/chart/Chart.lock
@@ -5,3 +5,5 @@ dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
   version: 15.1.5
+digest: sha256:f5b463f7862318ed8de9439769a72f14320f271c72c80ec7a2a1f1b209959d7a
+generated: "2024-08-06T10:52:12.01515499+01:00"

--- a/deploy/dracon/values/dev.yaml
+++ b/deploy/dracon/values/dev.yaml
@@ -27,9 +27,8 @@ arangodb:
     className: nginx
     host: arangodb.dracon.localhost
 
-global:
-  image:
-    registry: kind-registry:5000/ocurity/dracon
+image:
+  registry: kind-registry:5000/ocurity/dracon
 
 postgresql:
   enabled: true


### PR DESCRIPTION
This PR introduces two new ways of installing dracon

` make dev-deploy ` will build everything and deploy it to the local cluster
` make install` will download the latest version of every package and install it to the local cluster

both commands first setup the local cluster in an idempotent way 