### PR TITLE
fix reference to image.repository in deduplication migrations reference to not include deduplication_db_migrations dictionary

### DIFF
--- a/deploy/deduplication-db-migrations/chart/templates/_helpers.tpl
+++ b/deploy/deduplication-db-migrations/chart/templates/_helpers.tpl
@@ -67,10 +67,9 @@ Create the name of the service account to use
 */}}
 
 {{- define "deduplication_db_migrations.imageName" -}}
-{{- if .Values.deduplication_db_migrations.image.repository }}
-{{- printf "%s:%s" .Values.deduplication_db_migrations.image.repository (.Values.image.tag | default .Chart.AppVersion )}}
+{{- if .Values.image.repository }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion )}}
 {{- else }}
 {{- printf "%s/%s:%s" (.Values.image.registry | default "ghcr.io/ocurity/dracon") "draconctl" (.Values.image.tag | default .Chart.AppVersion )}}
 {{- end }}
 {{- end }}
-


### PR DESCRIPTION
Closes #324 