### PR TITLE
Feature/ocu 186 docs minor fixes in dracon oss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 tests/output
 .vscode/
 deploy/dracon/chart/charts
+.idea/

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ flowchart LR
 
 ## Getting Started
 
-The [Getting Started](docs/getting-started.md) tutorial explains how to get started
-with Dracon.
+The [Getting Started](docs/getting-started.md) tutorial explains
+how to get started with Dracon.
 You can also access our community contributed pipelines
 [here](https://github.com/ocurity/dracon-community-pipelines).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dracon
 
 [![Lint](https://github.com/ocurity/dracon/actions/workflows/lint.yml/badge.svg)](https://github.com/ocurity/dracon/actions/workflows/lint.yml)
-[![Run dracon](https://github.com/ocurity/dracon/actions/workflows/run_dracon.yml/badge.svg)](https://github.com/ocurity/dracon/actions/workflows/run_dracon.yml)
+[![Format](https://github.com/ocurity/dracon/actions/workflows/format.yml/badge.svg)](https://github.com/ocurity/dracon/actions/workflows/format.yml)
 [![Test](https://github.com/ocurity/dracon/actions/workflows/test.yml/badge.svg)](https://github.com/ocurity/dracon/actions/workflows/test.yml)
 [![Publish](https://github.com/ocurity/dracon/actions/workflows/publish.yml/badge.svg)](https://github.com/ocurity/dracon/actions/workflows/publish.yml)
 
@@ -16,7 +16,7 @@ By [Ocurity](https://ocurity.com)
 Security scanning,results unification and enrichment tool
 ([ASOC](https://www.gartner.com/reviews/market/application-security-orchestration-and-correlation-asoc-tools))
 
-* forked and rewritten from @thought-machine/dracon
+* forked and rewritten from [@thought-machine/dracon](https://github.com/thought-machine/dracon)
 
 Security pipelines on Kubernetes. The purpose of this project is to provide a
 scalable and flexible framework to execute arbitrary security scanning
@@ -67,24 +67,12 @@ flowchart LR
 
 ## Getting Started
 
-The [Getting started with KinD][tut-kind] tutorial explains how to get started
+The [Getting Started](docs/getting-started.md) tutorial explains how to get started
 with Dracon.
 You can also access our community contributed pipelines
-[here](https://github.com/ocurity/dracon-community-pipelines)
+[here](https://github.com/ocurity/dracon-community-pipelines).
 
-More tutorials:
-
-<!--lint disable maximum-line-length-->
-
-| Name                                                  | Description                                                          |
-| ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [Getting started with KinD][tut-kind]                 | Quickstart guide on how to get started with Dracon using KinD        |
-| [Getting started with Please and K3D][tut-please-k3d] | Beginner guide on how to get started with Dracon using Please w/ K3D |
-| [Running our demo pipeline][tut-running-demos]        | End to end demo of running an example pipeline                       |
-
-<!--lint enable maximum-line-length-->
-
-### Announcements
+## Announcements
 
 This version of Dracon was announced at OWASP Appsec Dublin in 2023. Check out
 [the slides](docs/presentations/Global_AppSecDublin_Presentation.pdf) and
@@ -94,7 +82,7 @@ of the presentation.
 ## Support
 
 If you have questions, reach out to us by opening a new
-[issue](https://github.com/ocurity/dracon/issues/new) on Github.
+[issue](https://github.com/ocurity/dracon/issues/new) on GitHub.
 
 ## Development & Contributing
 
@@ -105,9 +93,3 @@ and [releasing](docs/contributers/RELEASES.md) guides on how to get started.
 
 Dracon is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for
 details.
-
-[tut-kind]: docs/getting-started/kind.md
-
-[tut-please-k3d]: docs/getting-started/please-k3d.md
-
-[tut-running-demos]: docs/getting-started/tutorials/running-demos.md

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ By [Ocurity](https://ocurity.com)
 Security scanning,results unification and enrichment tool
 ([ASOC](https://www.gartner.com/reviews/market/application-security-orchestration-and-correlation-asoc-tools))
 
-* forked and rewritten from [@thought-machine/dracon](https://github.com/thought-machine/dracon)
-
 Security pipelines on Kubernetes. The purpose of this project is to provide a
 scalable and flexible framework to execute arbitrary security scanning
 tools on code and infrastructure while processing the results in a versatile

--- a/components/producers/github-code-scanning/README.md
+++ b/components/producers/github-code-scanning/README.md
@@ -1,5 +1,7 @@
 # Producer: GitHub Code Scanning
 
+<!--lint disable maximum-line-length-->
+
 This producer [queries the GitHub Code Scanning API](https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#list-code-scanning-alerts-for-a-repository) to produce SAST findings.
 
 ## Parameters
@@ -11,3 +13,5 @@ All parameters are **required**.
 | `producer-github-code-scanning-repository-owner` | `string` | N/A     | The owner of the repository to scan.                                                                                                                                                                                                                     |
 | `producer-github-code-scanning-repository-name`  | `string` | N/A     | The name of the repository to scan.                                                                                                                                                                                                                      |
 | `producer-github-code-scanning-github-token`     | `string` | N/A     | The GitHub token to use for scanning. Must have "Code scanning alerts" repository permissions (read) ([More Information](https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#list-code-scanning-alerts-for-a-repository)). |
+
+<!--lint enable maximum-line-length-->

--- a/components/producers/semgrep/README.md
+++ b/components/producers/semgrep/README.md
@@ -1,5 +1,7 @@
 # Producer: Semgrep
 
+<!--lint disable maximum-line-length-->
+
 This producer runs [the Semgrep CLI](https://semgrep.dev/docs/cli-reference) to produce SAST findings.
 
 ## Parameters
@@ -10,3 +12,5 @@ All parameters are optional. The producer works with the default configuration a
 | ------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------- |
 | `producer-semgrep-config-value` | `string` | `"auto"`      | The config for the Semgrep producer. Passed directly to the CLI via `--config`         |
 | `producer-semgrep-rules-yaml`   | `string` | `"rules: []"` | Additional rules passed to Semgrep https://semgrep.dev/docs/writing-rules/rule-syntax. |
+
+<!--lint enable maximum-line-length-->

--- a/components/producers/typescript-eslint/examples/README.md
+++ b/components/producers/typescript-eslint/examples/README.md
@@ -2,7 +2,11 @@
 
 ## dvna.json
 
+<!--lint disable maximum-line-length-->
+
 Using eslint with [eslint-plugin-security](https://www.npmjs.com/package/eslint-plugin-security) to generate the report.
+
+<!--lint enable maximum-line-length-->
 
 ```bash
 go run ../main.go -in ./dvna.json -out ./dvna.pb

--- a/deploy/dracon/values/dev.yaml
+++ b/deploy/dracon/values/dev.yaml
@@ -32,6 +32,8 @@ image:
 
 postgresql:
   enabled: true
+
+database:
   auth:
     username: dracon
     password: dracon

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,8 +3,8 @@
 This guide will help to quickly setup Dracon on a Kubernetes cluster and get a
 pipeline running. The first step is to create a dev Kubernetes cluster in order
 to deploy Tekton. We suggest you use KiND to provision a local test cluster
-quickly. If you already have a Kubernetes cluster then, you can skip directly to the
-[Deploying Dracon dependencies](#deploying-dracon-dependencies) section.
+quickly. If you already have a Kubernetes cluster then, you can skip directly
+to the [Deploying Dracon dependencies](#deploying-dracon-dependencies) section.
 
 We support two ways of deploying Dracon.
 
@@ -102,32 +102,32 @@ and MongoDB. The values used are in the `deploy/dracon/values/dev.yaml` file.
 
 1. Expose the TektonCD Dashboard
 
-    ```bash
-    kubectl -n tekton-pipelines port-forward svc/tekton-dashboard 9097:9097
-    ```
+```bash
+kubectl -n tekton-pipelines port-forward svc/tekton-dashboard 9097:9097
+```
 
 2. Expose the Kibana Dashboard.
 
-   ```bash
-    # Use `kubectl port-forward ...` to access the Kibana UI:
-    kubectl -n dracon port-forward svc/dracon-kb-kibana-kb-http 5601:5601
-    # You can obtain the password by examining the 
-    # `dracon-es-elasticsearch-es-elastic-user` secret:
-    # The username is `elastic`.
-    kubectl -n dracon get secret dracon-es-elasticsearch-es-elastic-user \
-      -o=jsonpath='{.data.elastic}' | \
-      base64 -d && \
-      echo
-   ```
+```bash
+# Use `kubectl port-forward ...` to access the Kibana UI:
+kubectl -n dracon port-forward svc/dracon-kb-kibana-kb-http 5601:5601
+# You can obtain the password by examining the 
+# `dracon-es-elasticsearch-es-elastic-user` secret:
+# The username is `elastic`.
+kubectl -n dracon get secret dracon-es-elasticsearch-es-elastic-user \
+  -o=jsonpath='{.data.elastic}' | \
+  base64 -d && \
+  echo
+```
 
 3. Expose the Kibana Dashboard
 
-    ```bash
-    # Use `kubectl port-forward ...` to access the Kibana UI:
-    kubectl -n dracon port-forward svc/dracon-kb-kibana-kb-http 5601:5601
-    ```
+```bash
+ # Use `kubectl port-forward ...` to access the Kibana UI:
+ kubectl -n dracon port-forward svc/dracon-kb-kibana-kb-http 5601:5601
+```
 
-   The username/password is the same as Kibana
+The username/password is the same as Kibana
 
 ### Deploy Dracon components
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,16 +168,15 @@ are using, if you are using something else:
 make publish-component-containers CONTAINER_REPO=localhost:5000/ocurity/dracon
 ```
 
-*Notice that the repo we are using is slightly different from the
+*\*Notice that the repo we are using is slightly different from the
 one we pushed the images in the previous step. That's because with local
 registries the registry is exposed on a port in localhost, however inside the
 KiND cluster, that's not the case. Instead, the registry's host is
 `kind-registry:5000`. This is also going to be important later when we will
 deploy the pipelines and their image repositories will also have to be set to
-this value.
-\
-\
-Make sure that you use the draconctl image that you pushed in the repository.*
+this value.*
+
+*\*\*Make sure that you use the draconctl image that you pushed in the repository.*
 
 #### Using a different base image for your images
 


### PR DESCRIPTION
Fixes:
 - Links and formatting issues in README and getting started docs.
 - Fixes incorrect/malformed commands in the getting started docs.
 - Fixes an error highlighted by Helm caused by a missing key `database` in the `dev.yam` values file
 - Ignores `.idea/` like we ignore `.vscode`