### PR TITLE
fix-bug-341-postgreql-does-not-have-credentials

### DIFF
--- a/deploy/dracon/chart/values.yaml
+++ b/deploy/dracon/chart/values.yaml
@@ -38,9 +38,10 @@ arangodb:
     className: ""
     host: ""
 
-postgresql:
-  # if set, a PostgreSQL instance will be deployed
-  enabled: true
+# this section controls the database that components have access to
+# the database should use the Postgres dialect.
+# the database is used by the deduplication enricher
+database: &psqlConfig
   host: ""
   auth:
     username: ""
@@ -50,19 +51,20 @@ postgresql:
     querystringargs: ""
   fullnameOverride: ""
 
+postgresql:
+  # if set, a PostgreSQL instance will be deployed
+  enabled: true
+  <<: *psqlConfig
+
+
 # this section controls aspects of managing a database used to store deduplication enrichments
 # the database should use the Postgres dialect.
 deduplication-db-migrations:
   # if set, a Job will be deployed that applies migrations to the deduplication database
   # the Job will run as part of the post-install/post-upgrade hook
   enabled: true
-  database:
-    host: ""
-    auth:
-      username: ""
-      password: ""
-      database: ""
-      querystringargs: ""
+  database: *psqlConfig
+
 
 image:
   # registry to use for all 

--- a/deploy/dracon/values/dev.yaml
+++ b/deploy/dracon/values/dev.yaml
@@ -30,28 +30,22 @@ arangodb:
 image:
   registry: kind-registry:5000/ocurity/dracon
 
-postgresql:
-  enabled: true
-
-database:
+database: &psqlConfig
+  host: dracon-postgresql:5432
   auth:
     username: dracon
     password: dracon
     database: dracon
     postgresPassword: dracon
     querystringargs: "sslmode=disable"
-  host: dracon-postgresql:5432
+
+postgresql:
+  enabled: true
+  <<: *psqlConfig
 
 tekton:
   enabled: true
 
 deduplication-db-migrations:
   enabled: true
-  database:
-    auth:
-      username: dracon
-      password: dracon
-      database: dracon
-      postgresPassword: dracon
-      querystringargs: "sslmode=disable"
-    host: dracon-postgresql:5432
+  database: *psqlConfig


### PR DESCRIPTION
closes #341 
A change in the last two weeks has removed the postgresql password. As a result postgres generates its own and thus no migrations or components can be run