### PR TITLE
Feature/ocu 184 allow binaries and containers to be built for architectures different than amd

### DIFF
--- a/components/consumers/dependency-track/Dockerfile
+++ b/components/consumers/dependency-track/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
 
-COPY ./components/consumers/dependency-track/dependency-track /app/components/consumers/dependency-track/dependency-track
+ARG GOOS=linux
+ARG GOARCH=amd64
+
+COPY ./components/consumers/dependency-track/${GOOS}/${GOARCH}/dependency-track /app/components/consumers/dependency-track/dependency-track
 
 ENTRYPOINT ["/app/components/consumers/dependency-track/dependency-track"]

--- a/components/consumers/dependency-track/Makefile
+++ b/components/consumers/dependency-track/Makefile
@@ -4,6 +4,13 @@ CONTAINER_REPO=
 DRACON_VERSION=
 SOURCE_CODE_REPO=
 PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -11,7 +18,10 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/consumers/dependency-track:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					 ../../../bin 1>&2
+					--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+					../../../bin 1>&2 \
+					--platform=$(CONTAINER_OS_ARCH)
 
 publish:
 	$(DOCKER) push $(CONTAINER_REPO)/components/consumers/dependency-track:$(DRACON_VERSION) 1>&2

--- a/components/consumers/jira/Dockerfile
+++ b/components/consumers/jira/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
 
-COPY ./components/consumers/jira/jira /app/components/consumers/jira/jira
+ARG GOOS=linux
+ARG GOARCH=amd64
+
+COPY ./components/consumers/jira/${GOOS}/${GOARCH}/jira /app/components/consumers/jira/jira
 
 ENTRYPOINT ["/app/components/consumers/jira/jira"]

--- a/components/consumers/jira/Makefile
+++ b/components/consumers/jira/Makefile
@@ -4,6 +4,13 @@ CONTAINER_REPO=
 DRACON_VERSION=
 SOURCE_CODE_REPO=
 PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -11,7 +18,10 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/consumers/jira:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					 ../../../bin 1>&2
+					--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+				 	../../../bin 1>&2 \
+				 	--platform=$(CONTAINER_OS_ARCH)
 
 publish:
 	$(DOCKER) push $(CONTAINER_REPO)/components/consumers/jira:$(DRACON_VERSION) 1>&2

--- a/components/consumers/pdf/Dockerfile
+++ b/components/consumers/pdf/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:latest
 
 WORKDIR /playwright
-RUN go mod init github.com/ocurity/pdf-consumer &&\
-    go get -u github.com/playwright-community/playwright-go &&\ 
-    go run github.com/playwright-community/playwright-go/cmd/playwright@latest install --with-deps
+RUN go mod init github.com/ocurity/pdf-consumer && \
+        go get -u github.com/playwright-community/playwright-go && \
+        go run github.com/playwright-community/playwright-go/cmd/playwright@latest install --with-deps
 
 ENV PATH="${PATH}:/go/pkg/mod/github.com/playwright-community"
 COPY components/consumers/pdf/pdf /playwright/pdf

--- a/components/consumers/slack/Dockerfile
+++ b/components/consumers/slack/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
 
-COPY ./components/consumers/slack/slack /app/components/consumers/slack/slack
+ARG GOOS=linux
+ARG GOARCH=amd64
+
+COPY ./components/consumers/slack/${GOOS}/${GOARCH}/slack /app/components/consumers/slack/slack
 
 ENTRYPOINT ["/app/components/consumers/slack/slack"]

--- a/components/consumers/slack/Makefile
+++ b/components/consumers/slack/Makefile
@@ -4,6 +4,13 @@ CONTAINER_REPO=
 DRACON_VERSION=
 SOURCE_CODE_REPO=
 PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -11,7 +18,10 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/consumers/slack:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					 ../../../bin 1>&2
+					--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+					../../../bin 1>&2 \
+					--platform=$(CONTAINER_OS_ARCH)
 
 publish:
 	$(DOCKER) push $(CONTAINER_REPO)/components/consumers/slack:$(DRACON_VERSION) 1>&2

--- a/components/producers/aggregator/Dockerfile
+++ b/components/producers/aggregator/Dockerfile
@@ -1,6 +1,9 @@
 ARG PRODUCER_AGGREGATOR_BASE_IMAGE
 FROM ${PRODUCER_AGGREGATOR_BASE_IMAGE}
 
-COPY ./components/producers/aggregator/aggregator-parser /app/components/producers/aggregator/tagger
+ARG GOOS=linux
+ARG GOARCH=amd64
+
+COPY ./components/producers/aggregator/${GOOS}/${GOARCH}/aggregator-parser /app/components/producers/aggregator/tagger
 
 ENTRYPOINT ["/app/components/producers/aggregator/tagger"]

--- a/components/producers/aggregator/Makefile
+++ b/components/producers/aggregator/Makefile
@@ -4,6 +4,13 @@ CONTAINER_REPO=
 DRACON_VERSION=
 SOURCE_CODE_REPO=
 PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -11,7 +18,10 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/producers/tagger:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					--build-arg PRODUCER_AGGREGATOR_BASE_IMAGE=$(PRODUCER_AGGREGATOR_BASE_IMAGE) ../../../bin 1>&2
+					--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+					--build-arg PRODUCER_AGGREGATOR_BASE_IMAGE=$(PRODUCER_AGGREGATOR_BASE_IMAGE) ../../../bin 1>&2 \
+					--platform=$(CONTAINER_OS_ARCH)
 
 publish:
 	$(DOCKER) push $(CONTAINER_REPO)/components/producers/tagger:$(DRACON_VERSION) 1>&2

--- a/components/producers/github-code-scanning/Dockerfile
+++ b/components/producers/github-code-scanning/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.20
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 RUN apk add --no-cache ca-certificates
 
-COPY ./components/producers/github-code-scanning/github-code-scanning-parser /app/components/producers/github-code-scanning/github-code-scanning-parser
+COPY ./components/producers/github-code-scanning/${GOOS}/${GOARCH}/github-code-scanning-parser /app/components/producers/github-code-scanning/github-code-scanning-parser
 
 ENTRYPOINT ["/app/components/producers/github-code-scanning/github-code-scanning-parser"]

--- a/components/producers/github-code-scanning/Makefile
+++ b/components/producers/github-code-scanning/Makefile
@@ -4,6 +4,13 @@ CONTAINER_REPO=
 DRACON_VERSION=
 SOURCE_CODE_REPO=
 PRODUCER_AGGREGATOR_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "scratch")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -11,7 +18,10 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/producers/github-code-scanning:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					 ../../../bin 1>&2
+				 	--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+				 	../../../bin 1>&2 \
+				 	--platform=$(CONTAINER_OS_ARCH)
 
 publish:
 	$(DOCKER) push $(CONTAINER_REPO)/components/producers/github-code-scanning:$(DRACON_VERSION) 1>&2

--- a/components/producers/typescript-eslint/eslint-wrapper/Dockerfile
+++ b/components/producers/typescript-eslint/eslint-wrapper/Dockerfile
@@ -1,10 +1,13 @@
 ARG ESLINT_WRAPPER_BASE_IMAGE
 FROM ${ESLINT_WRAPPER_BASE_IMAGE}
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 WORKDIR /home/node/workspace
 COPY components/producers/typescript-eslint/eslint-wrapper/eslintrc.js /home/node/workspace
 COPY components/producers/typescript-eslint/eslint-wrapper/package.json /home/node/workspace
-COPY bin/components/producers/typescript-eslint/eslint-wrapper/eslint-wrapper-parser /home/node/workspace/
+COPY bin/components/producers/typescript-eslint/eslint-wrapper/${GOOS}/${GOARCH}/eslint-wrapper-parser /home/node/workspace/
 
 RUN npm uninstall --save bcrypt &&\
     npm install --save-dev \
@@ -14,4 +17,4 @@ RUN npm uninstall --save bcrypt &&\
     eslint-plugin-no-unsanitized \
     eslint-plugin-security-node
 
-ENTRYPOINT [ "/home/node/workspace/eslint-wrapper-parser"]
+ENTRYPOINT ["/home/node/workspace/eslint-wrapper-parser"]

--- a/components/producers/typescript-eslint/eslint-wrapper/Makefile
+++ b/components/producers/typescript-eslint/eslint-wrapper/Makefile
@@ -3,6 +3,13 @@
 CONTAINER_REPO=
 DRACON_VERSION=
 ESLINT_WRAPPER_BASE_IMAGE=$(shell test -e .custom_image && cat .custom_image || echo "node:lts")
+# https://docs.docker.com/build/building/multi-platform/
+# Make sure to always build containers using AMD64 but allow to be overridden by users if need for cross-os compatibility.
+CONTAINER_OS_ARCH=linux/amd64
+# Allow to independently customise go OS and ARCH flags.
+# Defaulting to linux/amd64 as per CONTAINER_OS_ARCH.
+GOOS=linux
+GOARCH=amd64
 
 DOCKER=docker
 
@@ -10,4 +17,7 @@ container:
 	$(DOCKER) build --tag $(CONTAINER_REPO)/components/producers/typescript-eslint/eslint-wrapper:$(DRACON_VERSION) \
 					--file Dockerfile \
 					$$([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-					--build-arg ESLINT_WRAPPER_BASE_IMAGE=$(ESLINT_WRAPPER_BASE_IMAGE) ../../../.. 1>&2
+					--build-arg GOOS=$(GOOS) \
+					--build-arg GOARCH=$(GOARCH) \
+					--build-arg ESLINT_WRAPPER_BASE_IMAGE=$(ESLINT_WRAPPER_BASE_IMAGE) ../../../.. 1>&2 \
+					--platform=$(CONTAINER_OS_ARCH)

--- a/containers/Dockerfile.draconctl
+++ b/containers/Dockerfile.draconctl
@@ -1,9 +1,13 @@
 ARG BASE_MIGRATION_IMAGE
+
 FROM ${BASE_MIGRATION_IMAGE:-scratch}
+
+ARG GOOS=linux
+ARG GOARCH=amd64
 
 LABEL org.opencontainers.image.description "Draconctl is a command line tool for interacting with Dracon, you can find documentation for it at github.com/ocurity/dracon"
 
-COPY ./bin/cmd/draconctl /bin/draconctl
+COPY ./bin/cmd/${GOOS}/${GOARCH}/draconctl /bin/draconctl
 COPY ./pkg/enrichment/migrations /etc/dracon/migrations/enrichment
 
 ENTRYPOINT [ "/bin/draconctl" ]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,7 +176,8 @@ KiND cluster, that's not the case. Instead, the registry's host is
 deploy the pipelines and their image repositories will also have to be set to
 this value.*
 
-*\*\*Make sure that you use the draconctl image that you pushed in the repository.*
+*\*\*Make sure that you use the draconctl image that you pushed in the
+repository.*
 
 #### Using a different base image for your images
 
@@ -190,6 +191,45 @@ There are some components that require extra components or special treatment and
 these components have their own Makefiles. In those cases you can place a
 `.custom_image` file in the directory with the base image you wish to use and
 that will be picked up by the Makefile and build the container.
+
+#### Building binaries and images for non linux/amd64 architecture
+
+*\*Useful for Apple Silicon chips users.*
+
+###### Containers
+
+If you need your images to be built for non linux/amd64 architecture,
+you can supply the flag `CONTAINER_OS_ARCH` for customisation of containers.
+
+This can be passed to the make commands used to build images, for example:
+
+```bash
+make CONTAINER_OS_ARCH=linux/arm64 components
+```
+
+or:
+
+```bash
+make CONTAINER_OS_ARCH=linux/arm64 publish-containers
+```
+
+By default, when `CONTAINER_ARCH` is not supplied, `linux/amd64` is used.
+
+###### Binaries
+
+`GOOS` and `GOARCH` can be supplied for customisation of the go binaries.
+
+These can be passed to the make commands used to build binaries, for example:
+
+```bash
+make GOOS=linux GOARCH=arm64 component-binaries
+```
+
+By default `linux` and `amd64` are used.
+
+\**For Apple Silicon chips, you might want to use
+`GOOS=darwin` and `GOARCH=arm64` when building binaries
+locally for development.*
 
 #### Deploying your custom Dracon components Helm package
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "dracon",
       "devDependencies": {
-        "remark-cli": "^12.0.0",
+        "remark-cli": "^12.0.1",
         "remark-lint-list-item-indent": "^4.0.0",
         "remark-lint-no-shell-dollars": "^4.0.0",
         "remark-preset-lint-consistent": "^6.0.0",
@@ -698,10 +697,11 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.1.1.tgz",
-      "integrity": "sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -910,16 +910,6 @@
         "@npmcli/config": "^8.0.0",
         "import-meta-resolve": "^4.0.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/load-plugin/node_modules/import-meta-resolve": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
-      "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1838,12 +1828,13 @@
       }
     },
     "node_modules/remark-cli": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-12.0.0.tgz",
-      "integrity": "sha512-IGxCo2VsXC/GS2YdlF7+S8DsUiyULyiauik01NFoiMIrOlbDhXjrKLD8hYazwQdD67nw2k7cwOBIxcK/cbNd9Q==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-12.0.1.tgz",
+      "integrity": "sha512-2NAEOACoTgo+e+YAaCTODqbrWyhMVmlUyjxNCkTrDRHHQvH6+NbrnqVvQaLH/Q8Ket3v90A43dgAJmXv8y5Tkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "import-meta-resolve": "^3.0.0",
+        "import-meta-resolve": "^4.0.0",
         "markdown-extensions": "^2.0.0",
         "remark": "^15.0.0",
         "unified-args": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "devDependencies": {
-    "remark-cli": "^12.0.0",
+    "remark-cli": "^12.0.1",
     "remark-lint-list-item-indent": "^4.0.0",
     "remark-lint-no-shell-dollars": "^4.0.0",
     "remark-preset-lint-consistent": "^6.0.0",

--- a/scripts/build_component_binary.sh
+++ b/scripts/build_component_binary.sh
@@ -19,6 +19,9 @@ echo "${1}" | grep -Eq ^components/consumers/.*$ && executable="${executable}" |
 executable_src_path=$(dirname "${1}")
 executable_path=$(dirname $(dirname "${1}"))/"${executable}"
 
-echo "building bin/${executable_path}/${executable}" > /dev/stderr
+# Customised bin per OS/ARCH.
+out_bin_path="bin/${executable_src_path}/${GOOS}/${GOARCH}/${executable}"
 
-go build -o "bin/${executable_src_path}/${executable}" "./${executable_src_path}/main.go"
+echo "building $out_bin_path" > /dev/stderr
+
+go build -o $out_bin_path "./${executable_src_path}/main.go"

--- a/scripts/build_component_container.sh
+++ b/scripts/build_component_container.sh
@@ -4,35 +4,52 @@ set -e;
 
 source ./scripts/util.sh
 
+# Sanity check for not arguments being passed.
 if [ "$#" -eq 0 ]
 then
-    util::error "No directory provided to build"
+    util::error "No arguments provided to build. Expected two."
     exit 1
 fi
 
-executable=$(basename $(dirname "${1}"))
+if [ -z "$1" ]
+then
+    util::error "No directory argument provided to build."
+    exit 1
+fi
 
-echo "${1}" | grep -Eq ^components/producers/.*$ && executable="${executable}-parser" || true
-echo "${1}" | grep -Eq ^components/enrichers/.*$ && executable="${executable}" || true
-echo "${1}" | grep -Eq ^components/consumers/.*$ && executable="${executable}" || true
+if [ -z "$2" ]
+then
+    util::error "No build architecture argument provided to build."
+    exit 1
+fi
 
-executable_src_path=$(dirname "${1}")
-executable_path=$(dirname "${1}")/"${executable}"
+dir_name="$1"
+build_architecture="$2"
+
+executable=$(basename $(dirname ${dir_name}))
+
+echo ${dir_name} | grep -Eq ^components/producers/.*$ && executable="${executable}-parser" || true
+echo ${dir_name} | grep -Eq ^components/enrichers/.*$ && executable="${executable}" || true
+echo ${dir_name} | grep -Eq ^components/consumers/.*$ && executable="${executable}" || true
+
+executable_src_path=$(dirname $dir_name)
+executable_path=$(dirname $dir_name)/${build_architecture}/"${executable}"
 
 if make -C "${executable_src_path}" --no-print-directory --dry-run container >/dev/null 2>&1
 then
     make -C "${executable_src_path}" --no-print-directory --quiet container CONTAINER_REPO="${CONTAINER_REPO}" DRACON_VERSION="${DRACON_VERSION}"
 else
     dockerfile_template="
-        FROM ${BASE_IMAGE:-scratch}                     \n
-        COPY ${executable_path} /app/${executable_path} \n
-        ENTRYPOINT ["/app/${executable_path}"]          \n
+        FROM ${BASE_IMAGE:-scratch}                \n
+        COPY ${executable_path} /app/${executable} \n
+        ENTRYPOINT ["/app/${executable}"]          \n
     "
     dockerfile_path=$(mktemp)
     printf "${dockerfile_template}" > "${dockerfile_path}"
     docker build -t "${CONTAINER_REPO}/${executable_src_path}:${DRACON_VERSION}" \
         $([ "${SOURCE_CODE_REPO}" != "" ] && echo "--label=org.opencontainers.image.source=${SOURCE_CODE_REPO}" ) \
-        -f "${dockerfile_path}" ./bin
+        -f "${dockerfile_path}" ./bin \
+        --platform=${build_architecture}
 fi
 
 if make -C "${executable_src_path}" --no-print-directory --dry-run extras >/dev/null 2>&1


### PR DESCRIPTION
As per title, allow to customise the built images and binaries for 🍎 people and documenting the utilisation.

We basically use [--platform](https://docs.docker.com/build/building/multi-platform/) when building to specify for which platform we want to build an image. At the same time we can customise for which architecture the Go binaries should be built for.

---

Based on the supplied ARCH and OS, a binary is created in a self-documented sub-folder, as follows:

![Screenshot 2024-09-09 at 15 04 16](https://github.com/user-attachments/assets/2707bcb5-ad26-42ab-a0c8-f521ff0cdb57)

---

It would be nice to collapse the different `Dockerfile`s and `Makefile`s in components into a single one, so such customisation can be centralised. I'll start a thread in the chat about it.

---

Tested locally:
- `make components` -> builds with `linux/amd64` by default. Running the containers works fine.
- `make GOOS=linux GOARCH=arm64 CONTAINER_OS_ARCH=linux/arm64 components` -> builds with `linux/arm64`. Running the containers work.
- `make GOOS=darwin GOARCH=arm64 component-binaries` -> build with `darwin/arm64` and I can exec the binaries fine on my machine.

---

I would appreciate if you can try these commands yourself and if you have other pointers to what to test.

--- 

Minor: bumping `remark-cli` to v12.0.1 to suppress formatting errors.