### PR TITLE
Simplifying purl parsing and reachability flow for atom reachability …

### DIFF
--- a/components/enrichers/reachability/internal/atom/purl/purl_test.go
+++ b/components/enrichers/reachability/internal/atom/purl/purl_test.go
@@ -1,17 +1,88 @@
 package purl_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ocurity/dracon/components/enrichers/reachability/internal/atom/purl"
 )
 
-func TestNewParser(t *testing.T) {
-	t.Run("should return new parser with valid matchers", func(t *testing.T) {
-		p, err := purl.NewParser()
-		require.NoError(t, err)
-		require.NotNil(t, p)
-	})
+func TestParser_ParsePurl(t *testing.T) {
+	p, err := purl.NewParser()
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		inputPurl       string
+		expectedMatches []string
+		expectedError   bool
+	}{
+		{
+			inputPurl:     "hey",
+			expectedError: true,
+		},
+		{
+			inputPurl:     "pkg:bitbucket/birkenfeld/pygments-main",
+			expectedError: true,
+		},
+		{
+			inputPurl:     "pkg:bitbucket/birkenfeld/pygments-main@v1",
+			expectedError: true,
+		},
+		{
+			inputPurl:     "pkg:bitbucket/birkenfeld/pygments-main@v1.1",
+			expectedError: true,
+		},
+		{
+			inputPurl:     "pkg:bitbucket/birkenfeld/pygments-main@244",
+			expectedError: true,
+		},
+		{
+			inputPurl: "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",
+			expectedMatches: []string{
+				"birkenfeld/pygments-main:244fd47e07d1014f0aed9c",
+				"pygments-main:244fd47e07d1014f0aed9c",
+				"birkenfeld/pygments-main:244fd47",
+				"pygments-main:244fd47",
+			},
+		},
+		{
+			inputPurl: "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
+			expectedMatches: []string{
+				"debian/curl:7.50.3-1",
+				"curl:7.50.3-1",
+			},
+		},
+		{
+			inputPurl: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+			expectedMatches: []string{
+				"package-url/purl-spec:244fd47e07d1004f0aed9c",
+				"purl-spec:244fd47e07d1004f0aed9c",
+				"package-url/purl-spec:244fd47",
+				"purl-spec:244fd47",
+			},
+		},
+		{
+			inputPurl: "pkg:github/package-url/purl-spec@v1.2.3-beta",
+			expectedMatches: []string{
+				"package-url/purl-spec:v1.2.3-beta",
+				"purl-spec:v1.2.3-beta",
+			},
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("parsing with input %s should succeed: %v", tt.inputPurl, !tt.expectedError),
+			func(t *testing.T) {
+				pp, err := p.ParsePurl(tt.inputPurl)
+				if tt.expectedError {
+					require.Error(t, err)
+					assert.Nil(t, pp)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedMatches, pp)
+			})
+	}
 }


### PR DESCRIPTION
Simplified how we extract sub-parts to be used for reachability analysis in pURLS. Tested that we interpret correctly both SEMVER and SHA commits (with correct short version extraction for SHA).

Also simplified reachability flow.

---

All the existing tests pass showing that this works as expected :)