### PR TITLE
close #409, refactor Jira consumer,

### DIFF
--- a/components/consumers/jira/task.yaml
+++ b/components/consumers/jira/task.yaml
@@ -17,7 +17,7 @@ spec:
       type: string
     - name: consumer-jira-user
       type: string
-    - name: consumer-jira-config
+    - name: consumer-jira-project-name
       type: string
       default: ""
   workspaces:
@@ -30,7 +30,15 @@ spec:
     script: |
       mkdir -p $(workspaces.output.path)/.dracon/consumers/jira
       cat <<'EOF' > $(workspaces.output.path)/.dracon/consumers/jira/config.json
-      $(params.consumer-jira-config)
+       {
+      "defaultValues": {
+          "project": "$(params.consumer-jira-project-name)",
+          "issueType": "Task",
+          "customFields": null
+      },
+      "descriptionTemplate": "",
+      "mappings": null
+      }
       EOF
       cat $(workspaces.output.path)/.dracon/consumers/jira/config.json
   - name: run-consumer
@@ -46,7 +54,6 @@ spec:
       value: $(params.consumer-jira-url)
     - name: DRACON_JIRA_CONFIG_PATH
       value: $(workspaces.output.path)/.dracon/consumers/jira/config.json
-
     args: [
       "-in",
       "$(workspaces.output.path)/.dracon/enrichers/",

--- a/components/consumers/jira/utils/utils.go
+++ b/components/consumers/jira/utils/utils.go
@@ -35,10 +35,6 @@ func ProcessMessages(allowDuplicates, allowFP bool, sevThreshold int) ([]documen
 		return nil, 0, err
 	}
 	messages, discarded := ProcessEnrichedMessages(responses, allowDuplicates, allowFP, sevThreshold)
-	if err != nil {
-		log.Print("Could not Process Enriched messages: ", err)
-		return nil, 0, err
-	}
 	return messages, discarded, nil
 }
 

--- a/components/enrichers/custom-annotation/main.go
+++ b/components/enrichers/custom-annotation/main.go
@@ -28,7 +28,7 @@ func enrichIssue(i *apiv1.Issue, annotations string) (*apiv1.EnrichedIssue, erro
 	enrichedIssue := apiv1.EnrichedIssue{}
 	annotationMap := map[string]string{}
 	if err := json.Unmarshal([]byte(annotations), &annotationMap); err != nil {
-		return nil, errors.Errorf("could not unmarshall annotation object to map[string]string, err: %w", err)
+		return nil, errors.Errorf("could not unmarshall annotation object %s to map[string]string, err: %w", annotations, err)
 	}
 	enrichedIssue = apiv1.EnrichedIssue{
 		RawIssue:    i,

--- a/examples/pipelines/jira-project/kustomization.yaml
+++ b/examples/pipelines/jira-project/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -jira-project
+components:
+  - pkg:helm/dracon-oss-components/base
+  - pkg:helm/dracon-oss-components/git-clone
+  - pkg:helm/dracon-oss-components/producer-golang-gosec
+  - pkg:helm/dracon-oss-components/producer-golang-nancy
+  - pkg:helm/dracon-oss-components/producer-aggregator
+  - pkg:helm/dracon-oss-components/enricher-custom-annotation
+  - pkg:helm/dracon-oss-components/enricher-aggregator
+  - pkg:helm/dracon-oss-components/consumer-stdout-json
+  - pkg:helm/dracon-oss-components/consumer-jira

--- a/examples/pipelines/jira-project/pipelinerun.yaml
+++ b/examples/pipelines/jira-project/pipelinerun.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: dracon-jira-project-
+spec:
+  pipelineRef:
+    name: dracon-jira-project
+  params:
+  - name: git-clone-url
+    value: https://github.com/ocurity/e2e-monorepo.git
+  - name: consumer-jira-url
+    value: "$jira_url"
+  - name: consumer-jira-api-token
+    value: "$jira_token"
+  - name: consumer-jira-user
+    value: "$jira_user"
+  - name: consumer-jira-project-name
+    value: $jira_project_name
+  - name: enricher-custom-annotation-base-annotation
+    value: |
+      {
+        "found by other tools": "semgrep,toolmctoolface",
+        "training": "some training",
+        "knowledgebase": "cheatsheets"
+      }
+  - name:  enricher-custom-annotation-name
+    value: "magic"
+  workspaces:
+  - name: output
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/pkg/jira/config.yaml
+++ b/pkg/jira/config.yaml
@@ -39,20 +39,6 @@ defaultValues:
 ## simple-value: will translate to the special jira use case of "customfield_id":"value"
 ## simple-value is provided as a workaround when single-value does not work with your jira setup
 
-## Uncomment the fields you want included in the Issue's Description
-addToDescription:
-  - scan_start_time
-  # - scan_id
-  - tool_name
-  # - source
-  - target
-  - type
-  # - severity_text
-  # - cvss
-  - confidence_text
-  # - first_found
-  # - false_positive
-
 ## You can map fields from the Dracon Result into customfields specific to your Jira Workspace
 ## Note: You don't have to map all (or any) of the fields
 mappings:

--- a/pkg/jira/config/config_test.go
+++ b/pkg/jira/config/config_test.go
@@ -26,15 +26,6 @@ var sampleConfig = Config{
 		JiraField:   "customfield_10001",
 		FieldType:   "float",
 	}},
-	DescriptionExtras: []string{
-		"scan_start_time",
-		"tool_name",
-		"target",
-		"type",
-		"confidence_text",
-		"annotations",
-		"hash",
-	},
 	SyncMappings: []JiraToDraconVulnMappings{
 		{
 			JiraStatus:     "Test",

--- a/pkg/jira/config/types.go
+++ b/pkg/jira/config/types.go
@@ -4,7 +4,6 @@ package config
 type Config struct {
 	DefaultValues       DefaultValues              `json:"defaultValues"`
 	Mappings            []Mappings                 `json:"mappings"`
-	DescriptionExtras   []string                   `json:"addToDescription"`
 	DescriptionTemplate string                     `json:"descriptionTemplate"`
 	SyncMappings        []JiraToDraconVulnMappings `json:"syncMappings"`
 }

--- a/pkg/jira/jira/api.go
+++ b/pkg/jira/jira/api.go
@@ -56,7 +56,7 @@ func (c Client) assembleIssue(draconResult document.Document) *jira.Issue {
 		}
 	}
 	summary, extra := makeSummary(draconResult)
-	description := makeDescription(draconResult, c.Config.DescriptionExtras, c.Config.DescriptionTemplate)
+	description := makeDescription(draconResult, c.Config.DescriptionTemplate)
 	if extra != "" {
 		description = fmt.Sprintf(".... %s\n%s", extra, description)
 	}

--- a/pkg/jira/jira/api_test.go
+++ b/pkg/jira/jira/api_test.go
@@ -32,9 +32,8 @@ var (
 			JiraField:   "customfield_10001",
 			FieldType:   "float",
 		}},
-		DescriptionExtras: []string{"target", "tool_name"},
 	}
-	t, _         = time.Parse("0001-01-01T00:00:00Z", "0001-01-01T00:00:00Z")
+	t, _         = time.Parse(time.RFC3339, "2024-10-10T20:06:33Z")
 	sampleResult = document.Document{
 		ScanStartTime:  t,
 		ScanID:         "babbb83-4627-41c6-8ba0-70ee866290e9",
@@ -50,6 +49,8 @@ var (
 		FirstFound:     t,
 		FalsePositive:  "true",
 		CVE:            "CVE-0000-99999",
+		Annotations:    map[string]string{"foo": "bar", "foobar": "baz"},
+		Count:          "2",
 	}
 
 	expIssue = jira.Issue{
@@ -60,18 +61,8 @@ var (
 			Type: jira.IssueType{
 				Name: "Vulnerability",
 			},
-			Description: "Dracon found 'Unit Test Title'" +
-				" at '//foo1/bar1:baz2'," +
-				" severity 'SEVERITY_INFO'," +
-				" rule id: 'test type'," +
-				" CVSS '0'" +
-				" Confidence 'CONFIDENCE_INFO'" +
-				" Original Description: this is a test description," +
-				" Cve CVE-0000-99999,\n" +
-				"{code:}\n" +
-				"target:                    //foo1/bar1:baz2\n" +
-				"tool_name:                 spotbugs\n{code}\n",
-			Summary: "bar1:baz2 Unit Test Title",
+			Description: "spotbugs detected 'Unit Test Title' at //foo1/bar1:baz2 during scan started at: 2024-10-10T20:06:33Z with id babbb83-4627-41c6-8ba0-70ee866290e9.\nConfidence: Info\nThis issue has been detected 2 times before, first found on 2024-10-10T20:06:33Z\nOriginal Description is: 'this is a test description'\nspotbugs reported severity as Info\nSmithy enrichers added the following annotations:\nfoo:bar\nfoobar:baz\n\n",
+			Summary:     "bar1:baz2 Unit Test Title",
 			Components: []*jira.Component{
 				{Name: "c1"},
 				{Name: "c2"},
@@ -109,7 +100,7 @@ func TestAuthJiraClient(t *testing.T) {
 
 func TestAssembleIssue(t *testing.T) {
 	issue := sampleClient.assembleIssue(sampleResult)
-	assert.EqualValues(t, issue, &expIssue)
+	assert.EqualValues(t, &expIssue, issue)
 }
 
 func TestCreateIssue(t *testing.T) {

--- a/pkg/jira/jira/apiutils_test.go
+++ b/pkg/jira/jira/apiutils_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/trivago/tgo/tcontainer"
 )
 
@@ -33,7 +33,7 @@ func TestSetDefaultFields(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, res, exp)
+	require.EqualValues(t, res, exp)
 }
 
 func TestMakeCustomField(t *testing.T) {
@@ -53,35 +53,23 @@ func TestMakeCustomField(t *testing.T) {
 	res4 := makeCustomField("simple-value", []string{"test-value"})
 	exp4 := "test-value"
 
-	assert.EqualValues(t, res1, exp1)
-	assert.EqualValues(t, res2, exp2)
-	assert.Equal(t, res3, exp3)
-	assert.Equal(t, res4, exp4)
+	require.EqualValues(t, res1, exp1)
+	require.EqualValues(t, res2, exp2)
+	require.Equal(t, res3, exp3)
+	require.Equal(t, res4, exp4)
 }
 
 func TestMakeDescription(t *testing.T) {
-	extras := []string{"tool_name", "target", "confidence_text"}
-	res := makeDescription(sampleResult, extras, "")
-	exp := "Dracon found 'Unit Test Title' at '//foo1/bar1:baz2'," +
-		" severity 'SEVERITY_INFO'," +
-		" rule id: 'test type'," +
-		" CVSS '0' " +
-		"Confidence 'CONFIDENCE_INFO'" +
-		" Original Description: this is a test description," +
-		" Cve CVE-0000-99999,\n" +
-		"{code:}\n" +
-		"tool_name:                 spotbugs\n" +
-		"target:                    //foo1/bar1:baz2\n" +
-		"confidence_text:           Info\n" +
-		"{code}\n"
-	assert.Equal(t, res, exp)
+	res := makeDescription(sampleResult, "")
+	exp := "spotbugs detected 'Unit Test Title' at //foo1/bar1:baz2 during scan started at: 2024-10-10T20:06:33Z with id babbb83-4627-41c6-8ba0-70ee866290e9.\nConfidence: Info\nThis issue has been detected 2 times before, first found on 2024-10-10T20:06:33Z\nOriginal Description is: 'this is a test description'\nspotbugs reported severity as Info\nSmithy enrichers added the following annotations:\nfoo:bar\nfoobar:baz\n\n"
+	require.Equal(t, res, exp)
 }
 
 func TestMakeSummary(t *testing.T) {
 	res, extra := makeSummary(sampleResult)
 	exp := "bar1:baz2 Unit Test Title"
-	assert.Equal(t, res, exp)
-	assert.Equal(t, extra, "")
+	require.Equal(t, res, exp)
+	require.Equal(t, extra, "")
 
 	longTitle := make([]rune, 300)
 	truncatedSummary := make([]rune, 254)
@@ -107,7 +95,7 @@ func TestMakeSummary(t *testing.T) {
 	sampleResult.Title = string(longTitle)
 
 	res, extra = makeSummary(sampleResult)
-	assert.Equal(t, string(truncatedSummary), res)
+	require.Equal(t, string(truncatedSummary), res)
 
-	assert.Equal(t, string(expectedExtra), extra)
+	require.Equal(t, string(expectedExtra), extra)
 }

--- a/pkg/jira/jira/issueTemplate.txt
+++ b/pkg/jira/jira/issueTemplate.txt
@@ -1,0 +1,8 @@
+{{.ToolName}} detected '{{.RawIssue.Title}}' at {{.RawIssue.Target}} during scan started at: {{.ScanStartTime}} with id {{.ScanID}}.
+Confidence: {{.ConfidenceText}}
+{{ if gt .Count 0 }}This issue has been detected {{.Count}} times before, first found on {{.FirstFound}}{{ end }}
+Original Description is: '{{.RawIssue.Description}}'
+{{.ToolName}} reported severity as {{.SeverityText}}
+Smithy enrichers added the following annotations:
+{{ range $key, $value := .Annotations }}{{ $key }}:{{ $value }}
+{{ end }}

--- a/pkg/templating/template_description.go
+++ b/pkg/templating/template_description.go
@@ -5,6 +5,9 @@ package templating
 import (
 	"bytes"
 	"text/template"
+	"time"
+
+	"github.com/go-errors/errors"
 
 	v1 "github.com/ocurity/dracon/api/proto/v1"
 )
@@ -33,8 +36,98 @@ func TemplateStringRaw(inputTemplate string, issue *v1.Issue) (*string, error) {
 	return &res, nil
 }
 
+type enrichedIssue struct {
+	*v1.EnrichedIssue
+	ToolName       string
+	ScanStartTime  string
+	ScanID         string
+	ConfidenceText string
+	SeverityText   string
+	Count          uint
+	FirstFound     string
+}
+type enrichedIssueOption func(*enrichedIssue) error
+
+func EnrichedIssueWithToolName(toolname string) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if toolname == "" {
+			return errors.New("invalid toolname ''")
+		}
+		ei.ToolName = toolname
+		return nil
+	}
+}
+
+func EnrichedIssueWithScanStartTime(startTime time.Time) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if time.Time.IsZero(startTime) {
+			return errors.New("invalid startTime zero")
+		}
+		ei.ScanStartTime = startTime.Format(time.RFC3339)
+		return nil
+	}
+}
+
+func EnrichedIssueWithConfidenceText(confidence string) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if confidence == "" {
+			return errors.New("invalid confidence ''")
+		}
+		ei.ConfidenceText = confidence
+		return nil
+	}
+}
+
+func EnrichedIssueWithSeverityText(severity string) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if severity == "" {
+			return errors.New("invalid severity ''")
+		}
+		ei.SeverityText = severity
+		return nil
+	}
+}
+
+func EnrichedIssueWithCount(count uint) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if count <= 0 {
+			return errors.Errorf("invalid count %d", count)
+		}
+		ei.Count = count
+		return nil
+	}
+}
+
+func EnrichedIssueWithScanID(scanID string) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if scanID == "" {
+			return errors.New("invalid scanID ")
+		}
+		ei.ScanID = scanID
+		return nil
+	}
+}
+
+func EnrichedIssueWithFirstFound(firstFound time.Time) enrichedIssueOption {
+	return func(ei *enrichedIssue) error {
+		if time.Time.IsZero(firstFound) {
+			return errors.New("invalid firstFound zero")
+		}
+		ei.FirstFound = firstFound.Format(time.RFC3339)
+		return nil
+	}
+}
+
 // TemplateStringEnriched applies the provided go template to the Enriched Issue provided and returns the resulting str
-func TemplateStringEnriched(inputTemplate string, issue *v1.EnrichedIssue) (*string, error) {
+func TemplateStringEnriched(inputTemplate string, issue *v1.EnrichedIssue, opts ...enrichedIssueOption) (*string, error) {
+	enrichedIssue := &enrichedIssue{
+		EnrichedIssue: issue,
+	}
+	for _, opt := range opts {
+		if err := opt(enrichedIssue); err != nil {
+			return nil, errors.Errorf("could not apply enriched issue option: %w", err)
+		}
+	}
 	if inputTemplate == "" {
 		inputTemplate = defaultEnrichedFindingTemplate
 	}
@@ -44,7 +137,7 @@ func TemplateStringEnriched(inputTemplate string, issue *v1.EnrichedIssue) (*str
 	}
 	buf := new(bytes.Buffer)
 
-	err = tmpl.Execute(buf, issue)
+	err = tmpl.Execute(buf, enrichedIssue)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 remove addToDescription, instead offer a default template
now the only piece of jira config needed to run the consumer is the project name