### PR TITLE
Generating OCSF Go types from Proto Schema.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,9 +333,13 @@ lint-proto: build-buf-container
 	@echo "Linting Proto files"
 	$(MAKE) run-buf ARGS="lint --exclude-path vendor/"
 
+# Buf doesn't have a way to configure where to put the generated code from remote repositories;
+# that's why we make sure to correctly move it around. In this case it's just COM for OCSF types.
 generate-proto: build-buf-container
 	@echo "Generating Proto files"
 	$(MAKE) run-buf ARGS="generate"
+	@rm -rf api/gen
+	@mv com api/gen
 
 dep-update-proto: build-buf-container
 	@echo "Updating buf.lock deps"

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,3 +6,7 @@ plugins:
 inputs:
   - proto_file: api/proto/v1/issue.proto
   - proto_file: api/proto/v1/engine.proto
+  - git_repo: https://github.com/ocsf/examples
+    branch: main
+    ref: ba2a49f2bb1faf0c75ece9b6a9c5cd608eafbc67
+    subdir: encodings/protobuf/proto

--- a/containers/Dockerfile.buf
+++ b/containers/Dockerfile.buf
@@ -6,9 +6,25 @@ ENV GO111MODULE=on
 RUN go install github.com/bufbuild/buf/cmd/buf@v1.45.0
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1
 
+# Install git and its dependencies to enable cloning as we generate protos from remote for OCSF.
+FROM alpine AS git
+RUN apk --no-cache add git ca-certificates openssl
+RUN mkdir -p /git-deps/bin /git-deps/lib /git-deps/etc/ssl/certs
+RUN cp /usr/bin/git /git-deps/bin
+RUN cp /usr/libexec/git-core/git-remote-https /git-deps/bin/
+# Copying over libraries and certs so we can actually use git over https.
+RUN ldd /usr/bin/git | grep -o '/[^ ]*' | xargs -I '{}' cp '{}' /git-deps/lib
+RUN ldd /usr/libexec/git-core/git-remote-https | grep -o '/[^ ]*' | xargs -I '{}' cp '{}' /git-deps/lib/
+RUN cp /etc/ssl/certs/ca-certificates.crt /git-deps/etc/ssl/certs/ca-certificates.crt
+
 # Wrap everything together in a scratch container to do all things buf.
 FROM scratch
 COPY --from=golang /go/bin/buf /go/bin/buf
 COPY --from=golang /go/bin/protoc-gen-go /go/bin/protoc-gen-go
-ENV PATH="/go/bin:${PATH}"
+COPY --from=git /git-deps/bin/git /usr/bin/
+COPY --from=git /git-deps/bin/git-remote-https /usr/bin/
+COPY --from=git /git-deps/lib /lib/
+COPY --from=git /git-deps/etc/ssl/certs /etc/ssl/certs/
+ENV GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+ENV PATH="/go/bin:/usr/bin:${PATH}"
 ENTRYPOINT ["/go/bin/buf"]


### PR DESCRIPTION
Preparing for OSS work by generating Go types from [OSCF proto schema definition](https://github.com/ocsf/examples/tree/main/encodings/protobuf/proto).

Note: 
`buf` supports [git](https://buf.build//docs/reference/inputs#git) sources but funnily enough doesn't allow us to specify a destination for the generated code (like it usually happens for local development). Since buf relies on git for this remote generation, I added a bunch of stuff to the scratch image to allow so (I'm open to just use the base alpine image to simplify things if you think that it's tricky to understand).

---

>Why remote generation and not just copying over the type?
In this way we don't need to sync up manually and we can also target specific versions.

>Is there a buf schema registry for ocsf?
Nope https://buf.build/search?query=ocsf