### PR TITLE
Do not expand vendor/ changes on PR Diffs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vendor/**/* linguist-generated=true
+**/*.pb.go linguist-generated=true


### PR DESCRIPTION
Testing a GitHub customisation to flag generated code and do not expand changes to it on PR Diffs. This is a small QOL improvement for DevEx.

More info here https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github