### PR TITLE
fix: added missing env-var to readme

### DIFF
--- a/sdk/component/store/remote/findings-client/README.md
+++ b/sdk/component/store/remote/findings-client/README.md
@@ -11,3 +11,4 @@ This implementation of `component.Storer` interacts with a findings client via G
 | SMITHY\_REMOTE\_CLIENT\_INITIAL\_BACKOFF\_SECONDS    | duration in seconds | no       | 5s              | -                        |
 | SMITHY\_REMOTE\_CLIENT\_MAX\_BACKOFF\_SECONDS    | duration in seconds | no       | 60s             | -                        |
 | SMITHY\_REMOTE\_CLIENT\_BACKOFF\_MULTIPLIER    | float               | no       | 1.5             | -                        |
+| SMITHY\_REMOTE\_CLIENT\_PAGE\_SIZE | int | no | 100 | - |


### PR DESCRIPTION
Wouldn't we expect this also as a key in the readme?
https://github.com/smithy-security/smithy/blob/main/sdk/component/store/remote/findings-client/client.go
https://github.com/smithy-security/smithy/blob/main/sdk/component/store/remote/findings-client/README.md
![image](https://github.com/user-attachments/assets/9a38cf6d-f11b-456d-8b78-8fef22fb3162)
