### PR TITLE
Bump go image to v1.24.4 to build osv-scanner raw image.

### DIFF
--- a/components/scanners/osv-scanner/scanner/Dockerfile
+++ b/components/scanners/osv-scanner/scanner/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.23.4 AS builder
+FROM golang:1.24.4 AS builder
 
 COPY ./entrypoint.sh /entrypoint.sh
-RUN go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest &&\
+RUN go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.0.3 &&\
     chmod +x /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Fixes failing build for this custom Dockerfile https://github.com/smithy-security/smithy/actions/runs/15900653469/job/44842608843

This is not massively used now FWIW so we should be fine, rather than spending more time downgrading as the v2 is different from v1 and could break the scanner.
