### PR TITLE
don't swallow `context.DeadlineExceeded` errors

### DIFF
--- a/sdk/component/runner.go
+++ b/sdk/component/runner.go
@@ -153,5 +153,5 @@ func run(
 }
 
 func isContextErr(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.Canceled)
 }


### PR DESCRIPTION
the component runner currently ignores `context.DeadlineExceeded` errors, causing components to not fail when they time out.

timeouts represent an exceptional state and should be reported as such.